### PR TITLE
[FEAT] 해쉬태그 컴포넌트 구현

### DIFF
--- a/src/assets/svg/CircleXMarkSvg.tsx
+++ b/src/assets/svg/CircleXMarkSvg.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const CircleXMarkSvg = () => {
+  return (
+    <SvgIcon xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'>
+      <span>asd</span>
+      <path d='M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c9.4-9.4 24.6-9.4 33.9 0l47 47 47-47c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9l-47 47 47 47c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0l-47-47-47 47c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l47-47-47-47c-9.4-9.4-9.4-24.6 0-33.9z' />
+    </SvgIcon>
+  );
+};
+
+const SvgIcon = styled.svg`
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+`;
+
+export default CircleXMarkSvg;

--- a/src/components/HashTag.tsx
+++ b/src/components/HashTag.tsx
@@ -1,0 +1,51 @@
+import CircleXMarkSvg from '@/assets/svg/CircleXMarkSvg';
+import styled from 'styled-components';
+
+interface HashTagProps {
+  title: string;
+  isDeletable?: boolean;
+}
+
+const HashTag = ({ title, isDeletable }: HashTagProps) => {
+  return (
+    <Wrapper isDeletable={isDeletable}>
+      {isDeletable && <CircleXMarkSvg />}
+      <span>{title}</span>
+    </Wrapper>
+  );
+};
+
+HashTag.defaultProps = {
+  isDeletable: false,
+};
+
+const Wrapper = styled.span<{ isDeletable?: boolean }>`
+  background-color: #fff;
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid black;
+  border-radius: 5px;
+  padding: 6px 10px;
+  ${({ isDeletable }) =>
+    isDeletable &&
+    `
+    :hover {
+      svg {
+        display: block;
+      }
+    }
+  `}
+  svg {
+    display: none;
+    position: absolute;
+    top: -7px;
+    right: -6px;
+    :hover {
+      fill: red;
+    }
+  }
+`;
+
+export default HashTag;


### PR DESCRIPTION
## 개요 :mag:

재사용성 높은 해쉬태그 컴포넌트 구현

## 작업사항 :memo:

isDeletable props로 받아서 true일 때만 지울 수 있도록 구현

<img width="371" alt="Screenshot 2023-05-06 at 8 34 48 PM" src="https://user-images.githubusercontent.com/79697414/236621625-d80db76a-80a9-48e1-9d00-9c7d29783dd6.png">

