### PR TITLE
[FEAT] 카카오 로그인 기능 최소한으로 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env*.local
+.env
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next": "13.3.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-kakao-login": "^2.1.1",
     "styled-components": "^5.3.10",
     "typescript": "5.0.4"
   },

--- a/src/components/KaKaoBtn.tsx
+++ b/src/components/KaKaoBtn.tsx
@@ -1,0 +1,25 @@
+/* eslint-disable no-console */
+import React from 'react';
+import KakaoLogin from 'react-kakao-login';
+
+const KakaoBtn = () => {
+  const onSuccess = (response) => {
+    console.log(response);
+    // 성공 시 처리할 로직 작성
+  };
+
+  const onFailure = (error) => {
+    console.log(error);
+    // 실패 시 처리할 로직 작성
+  };
+
+  return (
+    <KakaoLogin
+      token={process.env.NEXT_PUBLIC_KAKAO_JS_KEY}
+      onSuccess={onSuccess}
+      onFail={onFailure}
+    />
+  );
+};
+
+export default KakaoBtn;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,17 @@
-import '@/styles/globals.css';
+import { kakaoInit } from '@/utils';
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
+import Script from 'next/script';
 
 const App = ({ Component, pageProps }: AppProps) => {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Head>
+        <Script src='https://developers.kakao.com/sdk/js/kakao.js' onLoad={kakaoInit} />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
 };
 
 export default App;

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,0 +1,7 @@
+import KakaoBtn from '@/components/KaKaoBtn';
+
+const Login = () => {
+  return <KakaoBtn />;
+};
+
+export default Login;

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -1,0 +1,8 @@
+declare namespace Kakao {
+  const init: (apiKey: string) => void;
+  // 다른 카카오 API도 필요한 경우 추가해야함.
+}
+
+interface Window {
+  Kakao: typeof Kakao;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,6 @@
-export {};
+export const kakaoInit = () => {
+  const kakao = window.Kakao;
+  kakao.init(process.env.NEXT_PUBLIC_KAKAO_JS_KEY);
+
+  return kakao;
+};


### PR DESCRIPTION
## 개요 :mag:

카카오 로그인 기능 구현

## 작업사항 :memo:

1. 카카오 버튼 컴포넌트
2. 카카오 홈페이지에서 앱 연결
3. 로그인 성공/실패 이후 로직은 구현안하고 기초만 구현함 -> 백앤드에서 구현 완료후 이어서 할 예정

## 테스트 방법(optional)

.env 파일을 추가해서 진아님 로컬환경에서도 동작하게끔 api 키를 추가해야함

<img width="237" alt="Screenshot 2023-05-07 at 5 46 17 PM" src="https://user-images.githubusercontent.com/79697414/236667490-6a93dd6f-2de5-46ee-a363-ecae11b473bc.png">
<img width="1291" alt="Screenshot 2023-05-07 at 5 46 24 PM" src="https://user-images.githubusercontent.com/79697414/236667495-cf038630-fb5b-489d-b79b-bbb30565be71.png">


