### PR TITLE
[Chore] configure styled components stylelint

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm run lint-front
+npm run lint:css

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,75 @@
+{
+  "extends": ["stylelint-config-standard"],
+  "plugins": ["stylelint-order"],
+  "customSyntax": "postcss-styled-syntax",
+  "rules": {
+    "declaration-empty-line-before": [
+      "always",
+      {
+        "ignore": ["first-nested", "after-comment", "after-declaration", "inside-single-line-block"]
+      }
+    ],
+    "order/properties-order": [
+      {
+        "groupName": "Layout",
+        "noEmptyLineBetween": true,
+        "properties": [
+          "display",
+          "visibility",
+          "overflow",
+          "float",
+          "clear",
+          "position",
+          "top",
+          "right",
+          "bottom",
+          "left",
+          "z-index"
+        ]
+      },
+      {
+        "groupName": "Box",
+        "emptyLineBefore": "always",
+        "noEmptyLineBetween": true,
+        "properties": [
+          "width",
+          "height",
+          "margin",
+          "margin-top",
+          "margin-right",
+          "margin-bottom",
+          "margin-left",
+          "padding",
+          "padding-top",
+          "padding-right",
+          "padding-bottom",
+          "padding-left",
+          "border"
+        ]
+      },
+      {
+        "groupName": "Background",
+        "emptyLineBefore": "always",
+        "noEmptyLineBetween": true,
+        "properties": ["background-color"]
+      },
+      {
+        "groupName": "Font",
+        "emptyLineBefore": "always",
+        "noEmptyLineBetween": true,
+        "properties": [
+          "color",
+          "font-style",
+          "font-weight",
+          "font-size",
+          "line-height",
+          "letter-spacing",
+          "text-align",
+          "text-indent",
+          "vertical-align",
+          "white-space"
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "prepare": "husky install",
-    "lint-front": "lint-staged"
+    "lint-front": "lint-staged",
+    "lint:css": "stylelint './src/**/*.tsx'"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
@@ -25,6 +26,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "styled-components": "^5.3.10",
+    "stylelint-order": "^6.0.3",
     "typescript": "5.0.4"
   },
   "devDependencies": {
@@ -44,6 +46,9 @@
     "eslint-webpack-plugin": "^3.1.1",
     "husky": "^8.0.0",
     "lint-staged": "^13.2.2",
-    "prettier": "^2.6.2"
+    "postcss-styled-syntax": "^0.4.0",
+    "prettier": "^2.6.2",
+    "stylelint": "^15.6.1",
+    "stylelint-config-standard": "^33.0.0"
   }
 }


### PR DESCRIPTION
## 개요 :mag:

css 코드 퀄리티를 위해 stylelint 도입하였습니다.

## 작업사항 :memo:

- #8  
- [styled components - stylelint](https://styled-components.com/docs/tooling#stylelint:~:text=)를 참고하여 stylelint를 적용했습니다. 
- style-order로 property 속성 순서를 정의하여 컨벤션을 강제했습니다.
- 속성을 자동으로 정렬하는 플러그인은 css-in-js 애서 사용할 수 없어 적용하지 않았습니다. 