### PR TITLE
[feat] 페이지 라우팅에 따른 헤더 분기처리

### DIFF
--- a/src/components/Explore/ExploreHeader.tsx
+++ b/src/components/Explore/ExploreHeader.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import Title from '@/components/Title.styled';
+import { Wrapper } from '../Home/HomeHeader';
+
+const ExploreHeader = () => {
+  return (
+    <Wrapper>
+      <nav>
+        <Link href='/explore'>
+          <Title>둘러보기</Title>
+        </Link>
+      </nav>
+    </Wrapper>
+  );
+};
+
+export default ExploreHeader;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,17 @@
 import GoBackBtn from '@/components/GoBackBtn';
 import styled from 'styled-components';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/store';
 
 const Header = () => {
+  const name = useSelector((state: RootState) => state.router.name);
+
   return (
     <Wrapper>
       <nav>
         {/* FIXME 뒤로가기 버튼 크기 조정 */}
         <GoBackBtn />
-        <span className='title'>Header</span>
+        <Title>{name}</Title>
       </nav>
     </Wrapper>
   );
@@ -28,16 +32,16 @@ const Wrapper = styled.header`
     flex-direction: row;
     align-items: center;
   }
+`;
 
-  .title {
-    position: absolute;
-    left: 50%;
-    transform: translate(-50%, 0);
+const Title = styled.span`
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, 0);
 
-    color: --var(--font-color-darkgray);
-    text-align: center;
-    font-weight: 600;
-    font-size: 18px;
-    line-height: 21px;
-  }
+  color: --var(--font-color-darkgray);
+  text-align: center;
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 21px;
 `;

--- a/src/components/Home/CreateBtn.tsx
+++ b/src/components/Home/CreateBtn.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 const CreateBtn = () => {
   return (
     <Wrapper>
-      <Link href='/'>
+      <Link href='/create'>
         <div className='button'>
           <span>
             <Image src='/assets/svg/add.svg' alt='' width={20} height={20} />

--- a/src/components/Home/HomeHeader.tsx
+++ b/src/components/Home/HomeHeader.tsx
@@ -19,7 +19,7 @@ const HomeHeader = () => {
 
 export default HomeHeader;
 
-const Wrapper = styled.header`
+export const Wrapper = styled.header`
   nav {
     display: flex;
     align-items: center;

--- a/src/components/Profile/ProfileHeader.tsx
+++ b/src/components/Profile/ProfileHeader.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import Title from '@/components/Title.styled';
+import { Wrapper } from '../Home/HomeHeader';
+
+const ProfileHeader = () => {
+  return (
+    <Wrapper>
+      <nav>
+        <Link href='/user'>
+          <Title>My</Title>
+        </Link>
+      </nav>
+    </Wrapper>
+  );
+};
+
+export default ProfileHeader;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,10 +1,29 @@
 import React from 'react';
 import BottomNav, { BottomNavHight } from '@/components/BottomNav';
 import styled from 'styled-components';
+import HomeHeader from '@/components/Home/HomeHeader';
+import Header from '@/components/Header';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/store';
+import ExploreHeader from '@/components/Explore/ExploreHeader';
+import ProfileHeader from '@/components/Profile/ProfileHeader';
 
 const MainLayout = ({ children }: { children: React.ReactNode }) => {
+  const { status, current } = useSelector((state: RootState) => state.router);
+  const main = status === 'MAIN';
+  const home = current === 'HOME';
+  const explore = current === 'EXPLORE';
+  const profile = current === 'PROFILE';
   return (
     <>
+      {!main && <Header />}
+      {main && (
+        <>
+          {home && <HomeHeader />}
+          {explore && <ExploreHeader />}
+          {profile && <ProfileHeader />}
+        </>
+      )}
       <Main>{children}</Main>
       <BottomNav />
     </>

--- a/src/pages/create/index.tsx
+++ b/src/pages/create/index.tsx
@@ -2,14 +2,14 @@ import { useAppDispatch } from '@/store';
 import { routerSlice } from '@/store/slices/routerSlice';
 import React, { useEffect } from 'react';
 
-const User = () => {
+const Create = () => {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    dispatch(routerSlice.actions.loadProfilePage());
+    dispatch(routerSlice.actions.loadCreatePage());
   }, [dispatch]);
 
-  return <div>User</div>;
+  return <div>create</div>;
 };
 
-export default User;
+export default Create;

--- a/src/pages/explore/index.tsx
+++ b/src/pages/explore/index.tsx
@@ -1,6 +1,14 @@
-import React from 'react';
+import { useAppDispatch } from '@/store';
+import { routerSlice } from '@/store/slices/routerSlice';
+import React, { useEffect } from 'react';
 
 const Explore = () => {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(routerSlice.actions.loadExplorePage());
+  }, [dispatch]);
+
   return <div>Explore</div>;
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,18 @@
 import CreateBtn from '@/components/Home/CreateBtn';
-import HomeHeader from '@/components/Home/HomeHeader';
 import LinkItem from '@/components/LinkItem';
+import { useAppDispatch } from '@/store';
+import { routerSlice } from '@/store/slices/routerSlice';
+import { useEffect } from 'react';
 
 const Home = () => {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(routerSlice.actions.loadHomePage());
+  }, [dispatch]);
+
   return (
     <div>
-      <HomeHeader />
       <CreateBtn />
 
       <LinkItem />

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -1,9 +1,11 @@
 import { combineReducers } from 'redux';
 import { HYDRATE } from 'next-redux-wrapper';
 import { exampleSlice } from './slices/exampleSlice';
+import { routerSlice } from './slices/routerSlice';
 
 const combinedReducer = combineReducers({
   auth: exampleSlice.reducer,
+  router: routerSlice.reducer,
 });
 
 const rootReducer: typeof combinedReducer = (state, action) => {

--- a/src/store/slices/routerSlice.ts
+++ b/src/store/slices/routerSlice.ts
@@ -1,0 +1,37 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+interface RouterState {
+  status: string;
+  current?: string;
+  name?: string;
+}
+
+const initialState: RouterState = {
+  status: 'MAIN',
+  current: '홈',
+  name: '',
+};
+
+export const routerSlice = createSlice({
+  name: 'router',
+  initialState,
+  reducers: {
+    loadHomePage(state) {
+      state.status = 'MAIN';
+      state.current = 'HOME';
+    },
+    loadExplorePage(state) {
+      state.status = 'MAIN';
+      state.current = 'EXPLORE';
+    },
+    loadProfilePage(state) {
+      state.status = 'MAIN';
+      state.current = 'PROFILE';
+    },
+    loadCreatePage(state) {
+      state.status = 'OTHER';
+      state.name = '링크 추가';
+    },
+    // 페이지 추가시 reducer추가
+  },
+});


### PR DESCRIPTION
## 개요 :mag:

페이지 전반적인 라우트 관리 로직 생성

## 작업사항 :memo:

close #45 

## 테스트 방법(optional)

bottomNav로 이동하는 페이지는 MAIN으로 규정했어요
그 외의 페이지는 OTHER로 처리하고 작은 헤더가 나올수 있도록 했어요

<img width="180" alt="Screenshot 2023-05-13 at 10 58 25 PM" src="https://github.com/linkarchive/Front-End/assets/79697414/2559891e-4093-4771-81d4-7b07bb23ebcc">
<img width="180" alt="Screenshot 2023-05-13 at 10 58 32 PM" src="https://github.com/linkarchive/Front-End/assets/79697414/338644ff-1f2c-4abb-af35-d96dc06ebc2e">
<img width="180" alt="Screenshot 2023-05-13 at 10 58 38 PM" src="https://github.com/linkarchive/Front-End/assets/79697414/336fe0e5-dd20-4df9-bde0-212f072a6213">
<img width="180" alt="Screenshot 2023-05-13 at 10 58 47 PM" src="https://github.com/linkarchive/Front-End/assets/79697414/0611e9e2-d05b-4e72-a8c0-85838a059a3e">
