### PR TITLE
[feat] https port 기능 추가

### DIFF
--- a/init-https.sh
+++ b/init-https.sh
@@ -1,0 +1,8 @@
+MKCERT_INSTALLED=$(which mkcert)
+
+if [ -z $MKCERT_INSTALLED ];then 
+    brew install mkcert
+fi
+
+mkcert -install
+mkcert localhost

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "sh init-https.sh && node server.js",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,32 @@
+const { createServer } = require('https');
+const { parse } = require('url');
+const next = require('next');
+const fs = require('fs');
+
+const hostname = 'localhost';
+const port = 3000;
+
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev, hostname, port });
+const handle = app.getRequestHandler();
+
+const httpsOptions = {
+  key: fs.readFileSync('localhost-key.pem'),
+  cert: fs.readFileSync('localhost.pem'),
+};
+
+app.prepare().then(() => {
+  createServer(httpsOptions, async (req, res) => {
+    try {
+      const parsedUrl = parse(req.url, true);
+      await handle(req, res, parsedUrl);
+    } catch (err) {
+      console.error('Error occurred handling', req.url, err);
+      res.statusCode = 500;
+      res.end('internal server error');
+    }
+  }).listen(port, (err) => {
+    if (err) throw err;
+    console.log(`> Ready on https://${hostname}:${port}`);
+  });
+});


### PR DESCRIPTION
## 개요 :mag:

api 서버가 https로 http인 localhost에서 api호출 cors에러가 나타남

## 작업사항 :memo:

close #61 

## 테스트 방법(optional)

mac에 brew가 깔려있어야함 이후에

1. next 캐시 지우기 
- rm -rf .next/cache
2. npm run dev
- script로 자동화 되어있음

