### PR TITLE
[Feat] 둘러보기 api 연동

### DIFF
--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -43,7 +43,12 @@ const API = {
   },
 
   getLinksArchive: async (linkId?: string) => {
-    const response = await authInstance.get(`links/archive?linkId=${linkId}`);
+    const response = await defaultInstance.get(`links/archive/public?linkId=${linkId}`);
+    return response;
+  },
+
+  getAuthLinksArchive: async (linkId?: string) => {
+    const response = await authInstance.get(`links/archive/authentication?linkId=${linkId}`);
     return response;
   },
 

--- a/src/components/LinkItem/LinkItem.type.ts
+++ b/src/components/LinkItem/LinkItem.type.ts
@@ -22,7 +22,7 @@ interface LinkItemProps extends LinkItem {
 interface LinkWithProfileProps extends LinkItemProps {
   userId: number;
   nickname: string;
-  profile_image: string;
+  profileImage: string;
 }
 
 export type { LinkItemProps, LinkWithProfileProps, Tag, MetaData };

--- a/src/components/LinkItem/LinkItem.type.ts
+++ b/src/components/LinkItem/LinkItem.type.ts
@@ -19,10 +19,10 @@ interface LinkItemProps extends LinkItem {
   Header?: JSX.Element;
 }
 
-interface LinkWithProfileProps extends LinkItemProps {
+interface LinkItemWithProfileProps extends LinkItemProps {
   userId: number;
   nickname: string;
   profileImage: string;
 }
 
-export type { LinkItemProps, LinkWithProfileProps, Tag, MetaData };
+export type { LinkItemProps, LinkItemWithProfileProps, Tag, MetaData };

--- a/src/components/LinkItem/LinkItem.type.ts
+++ b/src/components/LinkItem/LinkItem.type.ts
@@ -1,28 +1,27 @@
-interface MetaData {
+interface ILinkItem {
   title: string;
   thumbnail: string;
   description: string;
-}
-interface LinkItem extends MetaData {
   linkId: number;
   url: string;
   bookMarkCount: number;
   isRead: boolean;
   tagList: Tag[];
+  userId?: number;
+  nickname?: string;
+  profileImage?: string;
 }
+
+type MetaData = Pick<ILinkItem, 'title' | 'thumbnail' | 'description'>;
 
 interface Tag {
   tag: string;
 }
 
-interface LinkItemProps extends LinkItem {
+interface LinkItemProps extends ILinkItem {
   Header?: JSX.Element;
 }
 
-interface LinkItemWithProfileProps extends LinkItemProps {
-  userId: number;
-  nickname: string;
-  profileImage: string;
-}
+interface LinkItemWithProfileProps extends LinkItemProps {}
 
-export type { LinkItemProps, LinkItemWithProfileProps, Tag, MetaData };
+export type { LinkItemProps, LinkItemWithProfileProps, Tag, MetaData, ILinkItem };

--- a/src/components/LinkItem/LinkItem.type.ts
+++ b/src/components/LinkItem/LinkItem.type.ts
@@ -11,7 +11,9 @@ interface LinkItem extends MetaData {
   tagList: Tag[];
 }
 
-type Tag = string;
+interface Tag {
+  tag: string;
+}
 
 interface LinkItemProps extends LinkItem {
   Header?: JSX.Element;

--- a/src/components/LinkItem/LinkItem.type.ts
+++ b/src/components/LinkItem/LinkItem.type.ts
@@ -4,15 +4,14 @@ interface MetaData {
   description: string;
 }
 interface LinkItem extends MetaData {
-  urlId: number;
-  link: string;
+  linkId: number;
+  url: string;
   bookMarkCount: number;
+  isRead: boolean;
   tagList: Tag[];
 }
 
-interface Tag {
-  tag: unknown; // TODO 개선필요
-}
+type Tag = string;
 
 interface LinkItemProps extends LinkItem {
   Header?: JSX.Element;
@@ -20,8 +19,8 @@ interface LinkItemProps extends LinkItem {
 
 interface LinkWithProfileProps extends LinkItemProps {
   userId: number;
-  name: string;
-  profileImage: string;
+  nickname: string;
+  profile_image: string;
 }
 
 export type { LinkItemProps, LinkWithProfileProps, Tag, MetaData };

--- a/src/components/LinkItem/LinkItemLits.tsx
+++ b/src/components/LinkItem/LinkItemLits.tsx
@@ -1,8 +1,17 @@
-import LinkItemWithProfile from './LinkItemWithProfile';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import LinkItem, { LinkItemWithProfile } from '@/components/LinkItem';
 
-// TODO any 타입 개선
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const LinkItemList = ({ linkList }: { linkList: any }) => {
+const LinkItemList = ({ linkList }: { linkList: any[] }) => {
+  return (
+    <>
+      {linkList.map((linkItem, idx) => (
+        <LinkItem key={idx} {...linkItem} />
+      ))}
+    </>
+  );
+};
+
+const LinkItemWithProfileList = ({ linkList }: { linkList: any[] }) => {
   return (
     <>
       {linkList.map((linkItem, idx) => (
@@ -11,4 +20,34 @@ const LinkItemList = ({ linkList }: { linkList: any }) => {
     </>
   );
 };
-export default LinkItemList;
+
+export { LinkItemList, LinkItemWithProfileList };
+
+/** 
+ // TODO HOC 개선 
+import { ComponentType } from 'react';
+
+interface LinkItemProps {
+  [key: string]: string;
+}
+interface LinkItemListProps {
+  linkList: LinkItemProps[];
+}
+
+const withLinkItemList = <P extends object>(
+  WrappedComponent: ComponentType<P & LinkItemListProps>
+): React.FC<LinkItemListProps & P> => {
+  // eslint-disable-next-line react/display-name, @typescript-eslint/no-explicit-any, react/prop-types
+  return ({ linkList, ...props }) => {
+    return (
+      <>
+        {linkList.map((linkItem, idx) => (
+          <WrappedComponent {...linkItem} {...props} key={idx} />
+        ))}
+      </>
+    );
+  };
+};
+
+export default withLinkItemList;
+*/

--- a/src/components/LinkItem/LinkItemLits.tsx
+++ b/src/components/LinkItem/LinkItemLits.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import LinkItem, { LinkItemWithProfile } from '@/components/LinkItem';
+import LinkItem, { LinkItemWithProfile, ILinkItem } from '@/components/LinkItem';
 
-const LinkItemList = ({ linkList }: { linkList: any[] }) => {
+const LinkItemList = ({ linkList }: { linkList: ILinkItem[] }) => {
   return (
     <>
       {linkList.map((linkItem, idx) => (
@@ -11,7 +10,7 @@ const LinkItemList = ({ linkList }: { linkList: any[] }) => {
   );
 };
 
-const LinkItemWithProfileList = ({ linkList }: { linkList: any[] }) => {
+const LinkItemWithProfileList = ({ linkList }: { linkList: ILinkItem[] }) => {
   return (
     <>
       {linkList.map((linkItem, idx) => (

--- a/src/components/LinkItem/LinkItemWithProfile.tsx
+++ b/src/components/LinkItem/LinkItemWithProfile.tsx
@@ -3,12 +3,7 @@ import LinkItem, { LinkWithProfileProps } from '@/components/LinkItem';
 import styled from 'styled-components';
 import Link from 'next/link';
 
-const LinkWithProfile = ({
-  userId,
-  nickname,
-  profile_image: profileImage,
-  ...props
-}: LinkWithProfileProps) => {
+const LinkWithProfile = ({ userId, nickname, profileImage, ...props }: LinkWithProfileProps) => {
   const href = `/explore/user/${userId}`;
   return (
     <LinkItem

--- a/src/components/LinkItem/LinkItemWithProfile.tsx
+++ b/src/components/LinkItem/LinkItemWithProfile.tsx
@@ -1,17 +1,22 @@
 import Image from 'next/image';
-import LinkItem, { LinkWithProfileProps } from '@/components/LinkItem';
+import LinkItem, { LinkItemWithProfileProps } from '@/components/LinkItem';
 import styled from 'styled-components';
 import Link from 'next/link';
 
-const LinkWithProfile = ({ userId, nickname, profileImage, ...props }: LinkWithProfileProps) => {
-  const href = `/explore/user/${userId}`;
+const LinkWithProfile = ({
+  userId,
+  nickname,
+  profileImage,
+  ...props
+}: LinkItemWithProfileProps) => {
+  const href = `/archive/user/${userId}`;
   return (
     <LinkItem
       Header={
         <Profile>
           <Link href={href}>
             <div className='profile'>
-              <Image src={profileImage} alt='profile' />
+              {/* <Image src={profileImage} alt='profile' fill /> // TODO */}
             </div>
           </Link>
           <Link className='name' href={href}>

--- a/src/components/LinkItem/LinkItemWithProfile.tsx
+++ b/src/components/LinkItem/LinkItemWithProfile.tsx
@@ -3,7 +3,12 @@ import LinkItem, { LinkWithProfileProps } from '@/components/LinkItem';
 import styled from 'styled-components';
 import Link from 'next/link';
 
-const LinkWithProfile = ({ userId, name, profileImage, ...props }: LinkWithProfileProps) => {
+const LinkWithProfile = ({
+  userId,
+  nickname,
+  profile_image: profileImage,
+  ...props
+}: LinkWithProfileProps) => {
   const href = `/explore/user/${userId}`;
   return (
     <LinkItem
@@ -11,11 +16,11 @@ const LinkWithProfile = ({ userId, name, profileImage, ...props }: LinkWithProfi
         <Profile>
           <Link href={href}>
             <div className='profile'>
-              <img src={profileImage} alt='profile' />
+              <Image src={profileImage} alt='profile' />
             </div>
           </Link>
           <Link className='name' href={href}>
-            {name}
+            {nickname}
           </Link>
         </Profile>
       }

--- a/src/components/LinkItem/TagLabelList.tsx
+++ b/src/components/LinkItem/TagLabelList.tsx
@@ -3,18 +3,11 @@ import styled from 'styled-components';
 import { Tag } from '@/components/LinkItem/';
 
 const TagLabelList = ({ className, tags }: { className?: string; tags: Tag[] }) => {
-  const tagList = tags
-    ? (tags.reduce((arr: unknown[], item) => {
-        arr.push(Object.values(item)[0]);
-        return arr;
-      }, []) as string[])
-    : [];
-
   return (
     <Wrapper className={className}>
-      {tagList.map((tag, id) => (
-        <li key={`${tag}${id}`}>
-          <TagLabel text={tag as string} />
+      {tags.map((tag) => (
+        <li key={tag}>
+          <TagLabel text={tag} />
         </li>
       ))}
     </Wrapper>

--- a/src/components/LinkItem/TagLabelList.tsx
+++ b/src/components/LinkItem/TagLabelList.tsx
@@ -5,7 +5,7 @@ import { Tag } from '@/components/LinkItem/';
 const TagLabelList = ({ className, tags }: { className?: string; tags: Tag[] }) => {
   return (
     <Wrapper className={className}>
-      {tags.map((tag) => (
+      {tags.map(({ tag }) => (
         <li key={tag}>
           <TagLabel text={tag} />
         </li>

--- a/src/components/LinkItem/index.tsx
+++ b/src/components/LinkItem/index.tsx
@@ -4,7 +4,7 @@ import LinkItemWithProfile from '@/components/LinkItem/LinkItemWithProfile';
 import TagLabelList from '@/components/LinkItem/TagLabelList';
 import LinkInfo from '@/components/LinkItem/LinkInfo';
 import { LinkItemList, LinkItemWithProfileList } from '@/components/LinkItem/LinkItemLits';
-import { MetaData, LinkItemProps, LinkItemWithProfileProps, Tag } from './LinkItem.type';
+import { MetaData, LinkItemProps, LinkItemWithProfileProps, Tag, ILinkItem } from './LinkItem.type';
 
 const LinkItem = ({ Header, ...props }: LinkItemProps) => {
   const { linkId, url, title, description, thumbnail, isRead, bookMarkCount, tagList } = props;
@@ -51,7 +51,7 @@ const LinkItem = ({ Header, ...props }: LinkItemProps) => {
 
 export default LinkItem;
 export { LinkItem, LinkItemWithProfile, LinkInfo, LinkItemList, LinkItemWithProfileList };
-export type { MetaData, LinkItemProps, LinkItemWithProfileProps, Tag };
+export type { MetaData, LinkItemProps, LinkItemWithProfileProps, Tag, ILinkItem };
 
 const Wrapper = styled.div`
   padding: 24px 0 16px;

--- a/src/components/LinkItem/index.tsx
+++ b/src/components/LinkItem/index.tsx
@@ -6,7 +6,7 @@ import LinkInfo from '@/components/LinkItem/LinkInfo';
 import { MetaData, LinkItemProps, LinkWithProfileProps, Tag } from './LinkItem.type';
 
 const LinkItem = ({ Header, ...props }: LinkItemProps) => {
-  const { urlId, link, title, description, thumbnail, bookMarkCount, tagList } = props;
+  const { linkId, url, title, description, thumbnail, bookMarkCount, tagList } = props;
 
   return (
     <Wrapper>
@@ -15,7 +15,7 @@ const LinkItem = ({ Header, ...props }: LinkItemProps) => {
         <div className='info'>
           <div className='contents'>
             <h1 className='title'>{title}</h1>
-            <p className='domain'>{link}</p>
+            <p className='domain'>{url}</p>
             <p className='desc'>{description}</p>
           </div>
           <div className='thumb'>

--- a/src/components/LinkItem/index.tsx
+++ b/src/components/LinkItem/index.tsx
@@ -3,10 +3,11 @@ import Image from 'next/image';
 import LinkItemWithProfile from '@/components/LinkItem/LinkItemWithProfile';
 import TagLabelList from '@/components/LinkItem/TagLabelList';
 import LinkInfo from '@/components/LinkItem/LinkInfo';
-import { MetaData, LinkItemProps, LinkWithProfileProps, Tag } from './LinkItem.type';
+import { LinkItemList, LinkItemWithProfileList } from '@/components/LinkItem/LinkItemLits';
+import { MetaData, LinkItemProps, LinkItemWithProfileProps, Tag } from './LinkItem.type';
 
 const LinkItem = ({ Header, ...props }: LinkItemProps) => {
-  const { linkId, url, title, description, thumbnail, bookMarkCount, tagList } = props;
+  const { linkId, url, title, description, thumbnail, isRead, bookMarkCount, tagList } = props;
 
   return (
     <Wrapper>
@@ -28,12 +29,14 @@ const LinkItem = ({ Header, ...props }: LinkItemProps) => {
         <TagLabelList className='tag-list' tags={tagList} />
 
         <div className='utils'>
-          <div className='read'>
-            <div className='icon'>
-              <Image src='/assets/svg/check-green.svg' alt='' fill />
+          {isRead && (
+            <div className='read'>
+              <div className='icon'>
+                <Image src='/assets/svg/check-green.svg' alt='' fill />
+              </div>
+              읽음
             </div>
-            읽음
-          </div>
+          )}
           <button className='mark' type='button'>
             <div className='icon'>
               <Image src='/assets/svg/link.svg' alt='' fill />
@@ -47,8 +50,8 @@ const LinkItem = ({ Header, ...props }: LinkItemProps) => {
 };
 
 export default LinkItem;
-export { LinkItem, LinkItemWithProfile, LinkInfo };
-export type { MetaData, LinkItemProps, LinkWithProfileProps, Tag };
+export { LinkItem, LinkItemWithProfile, LinkInfo, LinkItemList, LinkItemWithProfileList };
+export type { MetaData, LinkItemProps, LinkItemWithProfileProps, Tag };
 
 const Wrapper = styled.div`
   padding: 24px 0 16px;


### PR DESCRIPTION
## 개요 :mag:

둘러보기 api 연동했습니다.

## 작업사항 :memo:

- #81 
- `ILinkItem` 인터페이스를 만들어 다른 타입으로 파생할 수 있도록 하여 타입을 관리하기 편하게 수정했습니다.
- 둘러보기 api를 call시 로그인한 상태에 따라 api를 콜하도록 하였습니다.

