### PR TITLE
[Feat] 사용자별 링크 둘러보기 api 연동

### DIFF
--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -42,13 +42,38 @@ const API = {
     return response;
   },
 
+  /** 링크 둘러보기 */
   getLinksArchive: async (linkId?: string) => {
     const response = await defaultInstance.get(`links/archive/public?linkId=${linkId}`);
     return response;
   },
 
   getAuthLinksArchive: async (linkId?: string) => {
-    const response = await authInstance.get(`links/archive/authentication?linkId=${linkId}`);
+    const response = await authInstance.get(`links/authentication?linkId=${linkId}`);
+    return response;
+  },
+
+  /** 사용자별 링크 둘러보기 */
+  getLinksArchiveByUserId: async ({ userId, linkId }: { userId: string; linkId?: string }) => {
+    const response = await defaultInstance.get(`links/public/user/${userId}?linkId=${linkId}`);
+    return response;
+  },
+
+  getAuthLinksArchiveByUserId: async ({ userId, linkId }: { userId: string; linkId?: string }) => {
+    const response = await authInstance.get(`links/authentication/user/${userId}?linkId=${linkId}`);
+    return response;
+  },
+
+  /** 사용자별 북마크 둘러보기 */
+  getMarksArchiveByUserId: async ({ userId, linkId }: { userId: string; linkId?: string }) => {
+    const response = await defaultInstance.get(`mark/links/public/user/${userId}?linkId=${linkId}`);
+    return response;
+  },
+
+  getAuthMarksArchiveByUserId: async ({ userId, linkId }: { userId: string; linkId?: string }) => {
+    const response = await authInstance.get(
+      `mark/links/authentication/user/${userId}?linkId=${linkId}`
+    );
     return response;
   },
 

--- a/src/components/Archive/User/Nav.tsx
+++ b/src/components/Archive/User/Nav.tsx
@@ -1,11 +1,30 @@
+import { useState } from 'react';
 import styled, { css } from 'styled-components';
 
-const Nav = () => {
+const Nav = ({ handleClick }: { handleClick: (item) => void }) => {
+  const [isLink, setIsLink] = useState(true);
+
   return (
     <Wrapper>
       <ul className='nav'>
-        <Item isActive>링크</Item>
-        <Item>마크</Item>
+        <Item
+          isActive={isLink}
+          onClick={() => {
+            setIsLink(true);
+            handleClick('link');
+          }}
+        >
+          링크
+        </Item>
+        <Item
+          isActive={!isLink}
+          onClick={() => {
+            setIsLink(false);
+            handleClick('mark');
+          }}
+        >
+          마크
+        </Item>
       </ul>
     </Wrapper>
   );

--- a/src/components/Archive/User/Profile.tsx
+++ b/src/components/Archive/User/Profile.tsx
@@ -1,15 +1,18 @@
 import styled from 'styled-components';
 import Image from 'next/image';
+import { User } from '@/components/Archive/User/User.type';
 
-const Profile = () => {
+interface ProfileProps extends User {}
+
+const Profile = ({ id, nickname, introduce, profileImageFileName }: ProfileProps) => {
   return (
     <Wrapper>
       <div className='profile-image'>
-        <Image alt='' src='/test.png' fill />
+        <Image alt='' src={profileImageFileName} fill />
       </div>
       <div className='info'>
-        <div className='name'>우ㅇ삼이</div>
-        <div className='desc'>안녕하세요</div>
+        <div className='nickname'>{nickname}</div>
+        <div className='introduce'>{introduce}</div>
       </div>
     </Wrapper>
   );
@@ -35,7 +38,7 @@ const Wrapper = styled.div`
     border-radius: 100%;
   }
 
-  .name {
+  .nickname {
     margin-bottom: 4px;
 
     font-weight: 700;
@@ -43,7 +46,7 @@ const Wrapper = styled.div`
     line-height: 14px;
   }
 
-  .desc {
+  .introduce {
     font-weight: 400;
     font-size: 12px;
     line-height: 14px;

--- a/src/components/Archive/User/User.type.ts
+++ b/src/components/Archive/User/User.type.ts
@@ -1,0 +1,8 @@
+type User = {
+  id: string;
+  profileImageFileName: string;
+  nickname: string;
+  introduce: string;
+};
+
+export type { User };

--- a/src/components/LinkItem/LinkItemLits.tsx
+++ b/src/components/LinkItem/LinkItemLits.tsx
@@ -1,21 +1,40 @@
 import LinkItem, { LinkItemWithProfile, ILinkItem } from '@/components/LinkItem';
 
-const LinkItemList = ({ linkList }: { linkList: ILinkItem[] }) => {
+interface IData {
+  data: {
+    linkList?: ILinkItem[];
+    linkArchive?: ILinkItem[];
+  };
+}
+
+const LinkItemList = ({ data }: { data: IData[] }) => {
   return (
     <>
-      {linkList.map((linkItem, idx) => (
-        <LinkItem key={idx} {...linkItem} />
-      ))}
+      {data.length <= 0 && <div>데이터가 없습니다.</div>}
+      {data.length > 0 &&
+        data.map(({ data: { linkList: linkArchive } }) => (
+          <>
+            {linkArchive.map((linkItem) => (
+              <LinkItem key={linkItem.linkId} {...linkItem} />
+            ))}
+          </>
+        ))}
     </>
   );
 };
 
-const LinkItemWithProfileList = ({ linkList }: { linkList: ILinkItem[] }) => {
+const LinkItemWithProfileList = ({ data }: { data: IData[] }) => {
   return (
     <>
-      {linkList.map((linkItem, idx) => (
-        <LinkItemWithProfile key={idx} {...linkItem} />
-      ))}
+      {data.length <= 0 && <div>데이터가 없습니다.</div>}
+      {data.length > 0 &&
+        data.map(({ data: { linkArchive } }) => (
+          <>
+            {linkArchive.map((linkItem) => (
+              <LinkItemWithProfile key={linkItem.linkId} {...linkItem} />
+            ))}
+          </>
+        ))}
     </>
   );
 };

--- a/src/hooks/useInfinityScroll.ts
+++ b/src/hooks/useInfinityScroll.ts
@@ -1,0 +1,43 @@
+import { useCallback, useRef } from 'react';
+import { QueryKey, useInfiniteQuery } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
+import useIntersectionObserver from '@/hooks/useIntersectionObserver';
+
+// TODO any 개선
+/* eslint-disable @typescript-eslint/no-explicit-any */
+interface IuseInfinityScroll {
+  queryKey: QueryKey;
+  fetchFn: (param?: unknown) => Promise<AxiosResponse<any, any>>;
+  getNextPageParam?: (lastPage: any, pages: any) => any;
+}
+
+const useInfinityScroll = ({ queryKey, fetchFn, getNextPageParam }: IuseInfinityScroll) => {
+  const target = useRef(null);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
+    queryKey,
+    queryFn: ({ pageParam }) => {
+      return fetchFn(pageParam || '');
+    },
+    getNextPageParam: (lastPage, pages) => getNextPageParam(lastPage, pages),
+    retry: 1,
+  });
+
+  const pages = data?.pages || [];
+
+  const handleIntersection = useCallback(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting && !isFetchingNextPage) {
+          hasNextPage && fetchNextPage();
+        }
+      });
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
+
+  useIntersectionObserver({ target, onIntersection: handleIntersection });
+
+  return { pages, target, isFetchingNextPage };
+};
+
+export default useInfinityScroll;

--- a/src/pages/archive/index.tsx
+++ b/src/pages/archive/index.tsx
@@ -1,10 +1,9 @@
 import API from '@/api/API';
 import { LinkItemWithProfileList } from '@/components/LinkItem';
-import useIntersectionObserver from '@/hooks/useIntersectionObserver';
+import useInfinityScroll from '@/hooks/useInfinityScroll';
 import { useAppDispatch } from '@/store';
 import { routerSlice } from '@/store/slices/routerSlice';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
 const Explore = () => {
@@ -16,13 +15,10 @@ const Explore = () => {
 
   const isUser = false;
   const fetchLinksFn = isUser ? API.getAuthLinksArchive : API.getLinksArchive;
-  const target = useRef(null);
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
+  const { pages, target, isFetchingNextPage } = useInfinityScroll({
+    fetchFn: fetchLinksFn,
     queryKey: ['archive'],
-    queryFn: ({ pageParam }) => {
-      return fetchLinksFn(pageParam || '');
-    },
     getNextPageParam: (lastPage_) => {
       const lastPage = lastPage_.data?.linkArchive;
       const lastItem = lastPage[lastPage.length - 1].urlId;
@@ -30,28 +26,11 @@ const Explore = () => {
 
       return hasNext ? lastItem : undefined;
     },
-    retry: 1,
   });
-
-  const pages = data?.pages || [];
-
-  const handleIntersection = useCallback(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting && !isFetchingNextPage) {
-          hasNextPage && fetchNextPage();
-        }
-      });
-    },
-    [fetchNextPage, hasNextPage, isFetchingNextPage]
-  );
-  useIntersectionObserver({ target, onIntersection: handleIntersection });
 
   return (
     <Wrapper>
-      {pages.map(({ data: { linkArchive } }) => (
-        <LinkItemWithProfileList linkList={linkArchive} key='' />
-      ))}
+      <LinkItemWithProfileList data={pages} />
       {isFetchingNextPage && <div>로딩중...</div>}
       <div ref={target} />
     </Wrapper>


### PR DESCRIPTION
## 개요 :mag:

사용자별 링크 둘러보기 api 연동

## 작업사항 :memo:
- 사용자별 링크, 마트 둘러보기 api 연동 작업
- 현재 사용자별 /archive/user/{userId}로 잡혀있어 https://github.com/linkarchive/Front-End/issues/102 수정 예정입니다.

close #81 
