### PR TITLE
[Feat] 내 링크, 내 마크 api 연동

### DIFF
--- a/src/components/Home/HomeHeader.tsx
+++ b/src/components/Home/HomeHeader.tsx
@@ -1,17 +1,28 @@
 import Link from 'next/link';
 import styled from 'styled-components';
 import Title from '@/components/Title.styled';
+import { useRouter } from 'next/router';
+
+const navLinks = [
+  {
+    path: '/',
+    name: '내 링크',
+  },
+  { path: '/mark', name: '내 마크' },
+];
 
 const HomeHeader = () => {
+  const router = useRouter();
+  const { pathname } = router;
+
   return (
     <Wrapper>
       <nav>
-        <Link href='/'>
-          <Title>내 링크</Title>
-        </Link>
-        <Link href='/'>
-          <Title color='#D9D9D9'>내 마크</Title>
-        </Link>
+        {navLinks.map(({ path, name }) => (
+          <Link href={path} key={path}>
+            <Title color={!(path === pathname) && '#D9D9D9'}>{name}</Title>
+          </Link>
+        ))}
       </nav>
     </Wrapper>
   );

--- a/src/components/LinkItem/LinkItemLits.tsx
+++ b/src/components/LinkItem/LinkItemLits.tsx
@@ -1,4 +1,5 @@
 import LinkItem, { LinkItemWithProfile, ILinkItem } from '@/components/LinkItem';
+import styled from 'styled-components';
 
 interface IData {
   data: {
@@ -10,15 +11,22 @@ interface IData {
 const LinkItemList = ({ data }: { data: IData[] }) => {
   return (
     <>
-      {data.length <= 0 && <div>데이터가 없습니다.</div>}
+      {(data[0]?.data?.linkArchive?.length <= 0 || data[0]?.data?.linkList?.length <= 0) && (
+        <Block>링크가 없습니다.</Block>
+      )}
+
       {data.length > 0 &&
-        data.map(({ data: { linkList: linkArchive } }) => (
-          <>
-            {linkArchive.map((linkItem) => (
-              <LinkItem key={linkItem.linkId} {...linkItem} />
-            ))}
-          </>
-        ))}
+        data.map(({ data: data_ }) => {
+          const linkList = data_.linkList || data_.linkArchive;
+
+          return (
+            <>
+              {linkList.map((linkItem) => (
+                <LinkItem key={linkItem.linkId} {...linkItem} />
+              ))}
+            </>
+          );
+        })}
     </>
   );
 };
@@ -26,7 +34,9 @@ const LinkItemList = ({ data }: { data: IData[] }) => {
 const LinkItemWithProfileList = ({ data }: { data: IData[] }) => {
   return (
     <>
-      {data.length <= 0 && <div>데이터가 없습니다.</div>}
+      {(data[0]?.data?.linkArchive?.length <= 0 || data[0]?.data?.linkList?.length <= 0) && (
+        <Block>링크가 없습니다.</Block>
+      )}
       {data.length > 0 &&
         data.map(({ data: { linkArchive } }) => (
           <>
@@ -40,6 +50,13 @@ const LinkItemWithProfileList = ({ data }: { data: IData[] }) => {
 };
 
 export { LinkItemList, LinkItemWithProfileList };
+
+const Block = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100px;
+`;
 
 /** 
  // TODO HOC 개선 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -32,11 +32,10 @@ export function middleware(request: NextRequest) {
 
   // 홈으로 이동 시
   if (request.nextUrl.pathname === '/') {
-    // 토큰이 있다면 본인 계정의 홈으로 이동
-    if (accessToken) {
-      return NextResponse.redirect(`${request.nextUrl.origin}/${nickname}`);
+    // 토큰이 없다면 로그인 홈으로 이동
+    if (!accessToken) {
+      return NextResponse.redirect(`${request.nextUrl.origin}/login`);
     }
-    // 토큰이 없다면 비로그인 홈으로 이동
     return NextResponse.next();
   }
 

--- a/src/pages/archive/user/[id].tsx
+++ b/src/pages/archive/user/[id].tsx
@@ -34,11 +34,10 @@ const User = () => {
     fetchFn: (linkId: string) => fetchLinksFn({ userId, linkId }),
     queryKey: ['linkList', item, userId],
     getNextPageParam: (lastPage_) => {
+      if (!lastPage_?.data?.hasNext) return undefined;
       const lastPage = lastPage_.data?.linkList;
       const lastItem = lastPage[lastPage.length - 1].urlId;
-      const hasNext = lastPage_?.data?.hasNext;
-
-      return hasNext ? lastItem : undefined;
+      return lastItem;
     },
   });
 

--- a/src/pages/mark.tsx
+++ b/src/pages/mark.tsx
@@ -1,12 +1,10 @@
 import API from '@/api/API';
-import CreateBtn from '@/components/Home/CreateBtn';
 import { LinkItemList } from '@/components/LinkItem';
 import useInfinityScroll from '@/hooks/useInfinityScroll';
 import { useAppDispatch } from '@/store';
 import { routerSlice } from '@/store/slices/routerSlice';
 import { useEffect } from 'react';
 
-// 비로그인 사용자 홈페이지
 const Home = () => {
   const dispatch = useAppDispatch();
 
@@ -15,8 +13,8 @@ const Home = () => {
   }, [dispatch]);
 
   const { pages, target, isFetchingNextPage } = useInfinityScroll({
-    fetchFn: (linkId: string) => API.getUserLinksArchive(linkId),
-    queryKey: ['linkList', 'user', 'link'],
+    fetchFn: (linkId: string) => API.getUserMarksArchive(linkId),
+    queryKey: ['linkList', 'user', 'mark'],
     getNextPageParam: (lastPage_) => {
       if (!lastPage_?.data?.hasNext) return undefined;
       const lastPage = lastPage_.data?.linkList;
@@ -27,7 +25,6 @@ const Home = () => {
 
   return (
     <div>
-      <CreateBtn />
       <LinkItemList data={pages} />
       {isFetchingNextPage && <div>로딩중...</div>}
       <div ref={target} />


### PR DESCRIPTION
## 개요 :mag:

내 링크, 내 마크 api 연동 작업입니다.

## 작업사항 :memo:

- #104 
- 내 링크(/), 내 마크(/mark) 라우팅을 추가했습니다.
- 현재 로그인 한 사용자는 `/nickname`으로 이동하는데 `/`으로 이동하도록 변경하였습니다 
  - #105 
  - 토큰이 있는 경우 `/`으로 이동합니다.
  - 토큰이 없는경우(비로그인) `/login` 이동합니다.

close #104 

