### PR TITLE
feat: add spinner while fetching link meta data

### DIFF
--- a/src/components/Input/InputWithButton.tsx
+++ b/src/components/Input/InputWithButton.tsx
@@ -2,15 +2,21 @@ import Input, { InputProps } from '@/components/Input';
 import styled from 'styled-components';
 
 interface InputWithButtonProps extends InputProps {
-  text: string;
+  text?: string;
+  ButtonChildren?: JSX.Element;
   onClick: (e) => void;
 }
 
-const InputWithButton = ({ text, onClick, ...inputProps }: InputWithButtonProps) => {
+const InputWithButton = ({
+  text,
+  ButtonChildren,
+  onClick,
+  ...inputProps
+}: InputWithButtonProps) => {
   return (
     <Input {...inputProps}>
       <Button type='button' onClick={onClick}>
-        {text}
+        {ButtonChildren || text}
       </Button>
     </Input>
   );

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -5,10 +5,11 @@ import SpinnerIcon from 'public/assets/svg/spinner.svg';
 interface SpinnerProps {
   width?: string;
   height?: string;
+  color?: string;
 }
 
-const Spinner = ({ width, height }: SpinnerProps) => {
-  return <AnimatedSpinner width={width} height={height} />;
+const Spinner = ({ width, height, color }: SpinnerProps) => {
+  return <AnimatedSpinner width={width} height={height} color={color} />;
 };
 
 Spinner.defaultProps = {
@@ -28,6 +29,7 @@ const spin = keyframes`
 const AnimatedSpinner = styled(SpinnerIcon)`
   width: ${(props) => props.width};
   height: ${(props) => props.height};
+  fill: ${(props) => props.color};
   animation: ${spin} 2s linear infinite;
 `;
 

--- a/src/pages/create/index.tsx
+++ b/src/pages/create/index.tsx
@@ -11,6 +11,7 @@ import LinkInfo from '@/components/Create/LinkInfo';
 import { MetaData } from '@/components/LinkItem';
 import { setAccessToken } from '@/api/customAPI';
 import { withAuth } from '@/lib/withAuth';
+import Spinner from '@/components/Spinner';
 // import HashTagList from '@/components/Create/HashTagList'; TODO mvp 이후 개발 */
 
 export const getServerSideProps = withAuth();
@@ -131,6 +132,7 @@ const Create = ({ accessToken }: { accessToken: string }) => {
       <InputBlock>
         <InputWithButton
           text='불러오기'
+          ButtonChildren={isLoading && <Spinner width='16' color='#fff' />}
           onClick={handleFetchURL}
           label='링크'
           errMessage={errorMessages.url}


### PR DESCRIPTION
## 개요 :mag:

링크 불러오기 중, 사용성 개선을 위해 스피너 추가했습니다

<img width="349" alt="스크린샷 2023-06-14 오후 6 29 44" src="https://github.com/linkarchive/Front-End/assets/123740296/12617056-bd34-4c95-9602-4b2f373e52f2">

## 작업사항 :memo:

링크 불러오기가 패칭되는 상태에서 스피너가 돌아갑니다
- #133
