### PR TITLE
[fix/feat] 레이아웃 깨짐 해결 & nickname page -> popup

### DIFF
--- a/src/components/Archive/NicknameModal.tsx
+++ b/src/components/Archive/NicknameModal.tsx
@@ -142,8 +142,9 @@ const slideUp = keyframes`
 `;
 
 const Wrapper = styled.div`
+  z-index: 100;
   position: fixed;
-  inset: 0 0 ${BottomNavHight} 0;
+  inset: 0;
   display: flex;
   margin: auto;
 

--- a/src/components/Archive/NicknameModal.tsx
+++ b/src/components/Archive/NicknameModal.tsx
@@ -16,7 +16,7 @@ export interface MessageWrapperProps {
   isValid: boolean;
 }
 
-const SetNickname = ({ userId }: { userId: string }) => {
+const NicknameModal = ({ userId }: { userId: string }) => {
   const router = useRouter();
   const [nickname, setNickname] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -259,4 +259,4 @@ const MessageWrapper = styled.div<MessageWrapperProps>`
   font-size: var(--font-size-sm);
 `;
 
-export default SetNickname;
+export default NicknameModal;

--- a/src/components/Archive/SetNickname.tsx
+++ b/src/components/Archive/SetNickname.tsx
@@ -11,18 +11,12 @@ import Spinner from '@/components/Spinner';
 import { BottomNavHight } from '@/components/BottomNav/BottomNav';
 import { useRouter } from 'next/router';
 import { ENGLISH_ONLY_REGEX } from '@/utils/regex';
-import { withAuth } from '@/lib/withAuth';
-import { setAccessToken } from '@/api/customAPI';
 
 export interface MessageWrapperProps {
   isValid: boolean;
 }
 
-export const getServerSideProps = withAuth();
-
-const SetNickname = ({ userId, accessToken }: { userId: string; accessToken: string }) => {
-  setAccessToken(accessToken);
-
+const SetNickname = ({ userId }: { userId: string }) => {
   const router = useRouter();
   const [nickname, setNickname] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -51,7 +45,7 @@ const SetNickname = ({ userId, accessToken }: { userId: string; accessToken: str
           onSuccess: async () => {
             await API.setCookie({ name: 'nickname', value: debouncedNickname });
 
-            window.location.href = '/';
+            window.location.href = '/archive';
           },
         }
       );
@@ -61,7 +55,7 @@ const SetNickname = ({ userId, accessToken }: { userId: string; accessToken: str
   const Logout = async () => {
     try {
       await API.deleteAllCookies();
-      router.push('/');
+      router.push('/login');
     } catch (error) {
       console.error(error);
     }
@@ -139,7 +133,7 @@ const SetNickname = ({ userId, accessToken }: { userId: string; accessToken: str
 };
 
 const Wrapper = styled.div`
-  position: absolute;
+  position: fixed;
   inset: 0 0 ${BottomNavHight} 0;
   display: flex;
   margin: auto;

--- a/src/components/Archive/SetNickname.tsx
+++ b/src/components/Archive/SetNickname.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import React, { useEffect, useState } from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import useDebounce from '@/hooks/useDebounce';
 import { DEBOUNCED_DELAY } from '@/constants';
 import CheckGreenSvg from 'public/assets/svg/check-green.svg';
@@ -132,6 +132,15 @@ const SetNickname = ({ userId }: { userId: string }) => {
   );
 };
 
+const slideUp = keyframes`
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+`;
+
 const Wrapper = styled.div`
   position: fixed;
   inset: 0 0 ${BottomNavHight} 0;
@@ -145,6 +154,7 @@ const Wrapper = styled.div`
 `;
 
 const Content = styled.div`
+  animation: ${slideUp} 0.8s ease-out;
   overflow: hidden;
   width: 330px;
   height: 230px;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,14 +5,19 @@ export function middleware(request: NextRequest) {
   const isLoggedIn = request.cookies.get(ACCESS_TOKEN)?.value;
   const nickname = request.cookies.get(NICKNAME)?.value || '';
 
-  if (isLoggedIn) {
+  // 비로그인 둘러보기 허용
+  if (!isLoggedIn) {
+    if (request.nextUrl.pathname === '/archive') {
+      return NextResponse.next();
+    }
+  } else if (isLoggedIn) {
     // 닉네임 설정 페이지로 이동 허용
-    if (!nickname && request.nextUrl.pathname === '/settings/profile/setnickname') {
+    if (!nickname && request.nextUrl.pathname === '/archive') {
       return NextResponse.next();
     }
     // 닉네임 설정 페이지로 이동
     if (!nickname) {
-      return NextResponse.redirect(`${request.nextUrl.origin}/settings/profile/setnickname`);
+      return NextResponse.redirect(`${request.nextUrl.origin}/archive`);
     }
     // 로그인 페이지 접근 불가
     if (request.nextUrl.pathname === '/login') {
@@ -25,5 +30,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/', '/create/:path*', '/settings/:path*', '/settings/profile/setnickname'],
+  matcher: ['/', '/create/:path*', '/settings/:path*', '/archive'],
 };

--- a/src/pages/archive/index.tsx
+++ b/src/pages/archive/index.tsx
@@ -8,16 +8,25 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { setAccessToken } from '@/api/customAPI';
 import { withAuth } from '@/lib/withAuth';
+import SetNickname from '@/components/Archive/SetNickname';
 
 export const getServerSideProps = withAuth();
 
-const Explore = ({ accessToken }: { accessToken: string }) => {
+const Archive = ({
+  accessToken,
+  nickname,
+  userId,
+}: {
+  accessToken: string;
+  nickname: string;
+  userId: string;
+}) => {
   setAccessToken(accessToken);
 
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    dispatch(routerSlice.actions.loadExplorePage());
+    dispatch(routerSlice.actions.loadArchivePage());
   }, [dispatch]);
 
   const { isLoggedin } = useAuth();
@@ -42,12 +51,14 @@ const Explore = ({ accessToken }: { accessToken: string }) => {
       <LinkItemWithProfileList data={pages} queryKey={queryKey} />
       {isFetchingNextPage && <div>로딩중...</div>}
       <div ref={target} />
+      {isLoggedin && !nickname && <SetNickname userId={userId} />}
     </Wrapper>
   );
 };
 
-export default Explore;
+export default Archive;
 
 const Wrapper = styled.div`
+  position: relative;
   height: 100%;
 `;

--- a/src/pages/archive/index.tsx
+++ b/src/pages/archive/index.tsx
@@ -8,7 +8,7 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { setAccessToken } from '@/api/customAPI';
 import { withAuth } from '@/lib/withAuth';
-import SetNickname from '@/components/Archive/SetNickname';
+import NicknameModal from '@/components/Archive/NicknameModal';
 
 export const getServerSideProps = withAuth();
 
@@ -51,7 +51,7 @@ const Archive = ({
       <LinkItemWithProfileList data={pages} queryKey={queryKey} />
       {isFetchingNextPage && <div>로딩중...</div>}
       <div ref={target} />
-      {isLoggedin && !nickname && <SetNickname userId={userId} />}
+      {isLoggedin && !nickname && <NicknameModal userId={userId} />}
     </Wrapper>
   );
 };

--- a/src/pages/settings/profile/index.tsx
+++ b/src/pages/settings/profile/index.tsx
@@ -9,10 +9,10 @@ import API from '@/api/API';
 import useDebounce from '@/hooks/useDebounce';
 import { DEBOUNCED_DELAY } from '@/constants';
 import { useMutation } from '@tanstack/react-query';
-import { MessageWrapperProps } from './setnickname';
 import { AxiosError } from 'axios';
 import { withAuth } from '@/lib/withAuth';
 import { setAccessToken } from '@/api/customAPI';
+import { MessageWrapperProps } from '@/components/Archive/SetNickname';
 
 interface ErrorMessage {
   message: string;

--- a/src/pages/settings/profile/index.tsx
+++ b/src/pages/settings/profile/index.tsx
@@ -12,7 +12,7 @@ import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { withAuth } from '@/lib/withAuth';
 import { setAccessToken } from '@/api/customAPI';
-import { MessageWrapperProps } from '@/components/Archive/SetNickname';
+import { MessageWrapperProps } from '@/components/Archive/NicknameModal';
 
 interface ErrorMessage {
   message: string;

--- a/src/store/slices/routerSlice.ts
+++ b/src/store/slices/routerSlice.ts
@@ -20,7 +20,7 @@ export const routerSlice = createSlice({
       state.status = 'MAIN';
       state.current = 'HOME';
     },
-    loadExplorePage(state) {
+    loadArchivePage(state) {
       state.status = 'MAIN';
       state.current = 'EXPLORE';
     },


### PR DESCRIPTION
## 개요 :mag:

닉네임 페이지 단독으로 렌더링 되다보니 사용자 경험이 떨어질 뿐만아니라 레이아웃 깨짐현상 발견

로그인 이후 랜딩페이지가 둘러보기임으로 둘러보기에서 닉네임이 없을 때 닉네임을 추가정보로 입력받는 컴포넌트를 popup으로 생성

## 작업사항 :memo:

close #128 

## 테스트 방법(optional)

<img width="396" alt="Screenshot 2023-06-19 at 5 18 10 PM" src="https://github.com/linkarchive/Front-End/assets/79697414/82f72c7c-ae5b-4c5d-8bdf-9d44666d2e7c">

