### PR TITLE
[fix] 사용자 프로필 Layout으로 분리

### DIFF
--- a/src/layouts/ProfileLayout.tsx
+++ b/src/layouts/ProfileLayout.tsx
@@ -1,0 +1,28 @@
+import API from '@/api/API';
+import Profile from '@/components/Archive/User/Profile';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+
+type ProfileLayoutProps = {
+  children: React.ReactNode;
+};
+
+const ProfileLayout = ({ children }: ProfileLayoutProps) => {
+  const router = useRouter();
+  const nickname = (router.query.nickname as string) || '';
+
+  const { data: profile } = useQuery({
+    queryKey: ['user', nickname],
+    queryFn: () => API.getUserProfile(nickname),
+    enabled: !!nickname,
+  });
+
+  return (
+    <>
+      <Profile {...profile} />
+      {children}
+    </>
+  );
+};
+
+export default ProfileLayout;

--- a/src/pages/[nickname]/index.tsx
+++ b/src/pages/[nickname]/index.tsx
@@ -10,7 +10,7 @@ import useAuth from '@/hooks/useAuth';
 import ProfileLayout from '@/layouts/ProfileLayout';
 import { NextPageWithLayout } from '../_app';
 
-const Page: NextPageWithLayout = () => {
+const User: NextPageWithLayout = () => {
   const dispatch = useAppDispatch();
 
   const router = useRouter();
@@ -44,9 +44,9 @@ const Page: NextPageWithLayout = () => {
   );
 };
 
-export default Page;
+export default User;
 
-Page.getLayout = function getLayout(page: ReactElement) {
+User.getLayout = function getLayout(page: ReactElement) {
   return <ProfileLayout>{page}</ProfileLayout>;
 };
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,11 +8,23 @@ import wrapper, { persistor } from '@/store';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 import { System } from '@/layouts/System';
+import { ReactElement, ReactNode } from 'react';
+import { NextPage } from 'next';
 
 const queryClient = new QueryClient();
 
-const App = ({ Component, ...rest }: AppProps) => {
+export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+const App = ({ Component, ...rest }: AppPropsWithLayout) => {
   const { store, props } = wrapper.useWrappedStore(rest);
+
+  const getLayout = Component.getLayout ?? ((page) => page);
 
   return (
     <Provider store={store}>
@@ -22,7 +34,7 @@ const App = ({ Component, ...rest }: AppProps) => {
           <System />
           <MainLayout>
             <QueryClientProvider client={queryClient}>
-              <Component {...props.pageProps} />
+              {getLayout(<Component {...props.pageProps} />)}
             </QueryClientProvider>
           </MainLayout>
         </ThemeProvider>


### PR DESCRIPTION
## 개요 :mag:

/[nickname] 페이지 이동후 링크/마크 이동간에 프로필 조회 api 계속 호출로 인해 데이터 낭비

layout으로 분리해서 첫 렌더링시 조회하고 그 이후는 SWR로 처리

## 작업사항 :memo:

close #135 

