### PR TITLE
Fix/linkitem layout

### DIFF
--- a/src/components/LinkItem/LinkInfo.tsx
+++ b/src/components/LinkItem/LinkInfo.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Desc, InfoWrapper, LinkContents } from '@/components/LinkItem/LinkItem.styled';
+import { Desc, InfoWrapper, LinkMetaWrapper } from '@/components/LinkItem/LinkItem.styled';
 import { MetaData } from '@/components/LinkItem/LinkItem.type';
 import { Thumbnail } from '@/components/LinkItem/LinkItem';
 
@@ -7,7 +7,7 @@ const LinkInfoWrapper = styled(InfoWrapper)`
   width: 100%;
 `;
 
-const LinkInfoContents = styled(LinkContents)`
+const LinkInfoMetaWrapper = styled(LinkMetaWrapper)`
   display: flex;
   align-items: center;
 `;
@@ -15,9 +15,9 @@ const LinkInfoContents = styled(LinkContents)`
 const LinkInfo = ({ metaThumbnail: thumbnail, metaDescription: description }: MetaData) => {
   return (
     <LinkInfoWrapper>
-      <LinkInfoContents>
+      <LinkInfoMetaWrapper>
         <Desc>{description}</Desc>
-      </LinkInfoContents>
+      </LinkInfoMetaWrapper>
       <Thumbnail src={thumbnail} alt='' />
     </LinkInfoWrapper>
   );

--- a/src/components/LinkItem/LinkItem.styled.tsx
+++ b/src/components/LinkItem/LinkItem.styled.tsx
@@ -32,14 +32,52 @@ const LinkContents = styled.div`
   line-height: 14px;
 `;
 
-const InfoWrapper = styled.div`
+const LinkItem = styled.div`
+  width: 317px;
+  margin: 0 auto;
+`;
+
+const InfoWrapper = styled(LinkItem)`
   display: flex;
   flex-direction: row;
 
-  width: 317px;
   min-height: 84px;
-  margin: 0 auto;
   gap: 10px;
 `;
 
-export { Desc, Thumb, LinkContents, InfoWrapper };
+const UtilsWrapper = styled(LinkItem)`
+  .utils {
+    display: flex;
+    justify-content: flex-end;
+
+    .read,
+    .mark {
+      display: flex;
+      flex-direction: row;
+
+      font-style: normal;
+      font-weight: 400;
+      font-size: 12px;
+      line-height: 14px;
+      color: #858585;
+    }
+
+    .read {
+      margin-right: 8px;
+    }
+
+    .mark {
+      cursor: pointer;
+    }
+
+    .icon {
+      position: relative;
+
+      width: 12px;
+      height: 12px;
+      margin-right: 4px;
+    }
+  }
+`;
+
+export { Desc, Thumb, LinkContents, InfoWrapper, UtilsWrapper };

--- a/src/components/LinkItem/LinkItem.styled.tsx
+++ b/src/components/LinkItem/LinkItem.styled.tsx
@@ -1,5 +1,26 @@
 import styled from 'styled-components';
 
+const LinkItem = styled.div`
+  width: 317px;
+  margin: 0 auto;
+`;
+
+const InfoWrapper = styled(LinkItem)`
+  display: flex;
+  flex-direction: row;
+
+  min-height: 84px;
+  gap: 10px;
+`;
+
+const LinkContents = styled.div`
+  overflow: hidden;
+
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 14px;
+`;
+
 const Desc = styled.p`
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -22,27 +43,6 @@ const Thumb = styled.div`
 
     font-size: var(--font-size-sm);
   }
-`;
-
-const LinkContents = styled.div`
-  overflow: hidden;
-
-  font-weight: 400;
-  font-size: 12px;
-  line-height: 14px;
-`;
-
-const LinkItem = styled.div`
-  width: 317px;
-  margin: 0 auto;
-`;
-
-const InfoWrapper = styled(LinkItem)`
-  display: flex;
-  flex-direction: row;
-
-  min-height: 84px;
-  gap: 10px;
 `;
 
 const UtilsWrapper = styled(LinkItem)`

--- a/src/components/LinkItem/LinkItem.styled.tsx
+++ b/src/components/LinkItem/LinkItem.styled.tsx
@@ -13,7 +13,7 @@ const InfoWrapper = styled(LinkItem)`
   gap: 10px;
 `;
 
-const LinkContents = styled.div`
+const LinkMetaWrapper = styled.div`
   overflow: hidden;
 
   font-weight: 400;
@@ -80,4 +80,4 @@ const UtilsWrapper = styled(LinkItem)`
   }
 `;
 
-export { Desc, Thumb, LinkContents, InfoWrapper, UtilsWrapper };
+export { Desc, Thumb, LinkMetaWrapper, InfoWrapper, UtilsWrapper };

--- a/src/components/LinkItem/LinkItem.tsx
+++ b/src/components/LinkItem/LinkItem.tsx
@@ -7,7 +7,7 @@ import IcoMark from 'public/assets/svg/link.svg';
 import {
   Desc,
   InfoWrapper,
-  LinkContents,
+  LinkMetaWrapper,
   Thumb,
   UtilsWrapper,
 } from '@/components/LinkItem/LinkItem.styled';
@@ -74,11 +74,11 @@ const LinkItem = ({ Header, queryKey, ...props }: LinkItemProps) => {
       <article>
         {Header}
         <LinkItemInfoWrapper onClick={handleLinkClick}>
-          <LinkContents>
+          <LinkMetaWrapper>
             <h1 className='title'>{title}</h1>
             <p className='domain'>{url}</p>
             <Desc>{description}</Desc>
-          </LinkContents>
+          </LinkMetaWrapper>
           <Thumbnail src={thumbnail} alt={title} />
         </LinkItemInfoWrapper>
 

--- a/src/components/LinkItem/LinkItem.tsx
+++ b/src/components/LinkItem/LinkItem.tsx
@@ -83,7 +83,7 @@ const LinkItem = ({ Header, queryKey, ...props }: LinkItemProps) => {
         </LinkItemInfoWrapper>
 
         <UtilsWrapper>
-          <TagLabelList className='tag-list' tags={[{ tagId: 1, tagName: 'qwer' }]} />
+          <TagLabelList className='tag-list' tags={tagList} />
           <div className='utils'>
             {isRead && (
               <div className='read'>

--- a/src/components/LinkItem/LinkItem.tsx
+++ b/src/components/LinkItem/LinkItem.tsx
@@ -4,7 +4,13 @@ import { useToggleMark } from '@/hooks/useToggleMark';
 import { LinkItemProps } from '@/components/LinkItem/LinkItem.type';
 import TagLabelList from '@/components/LinkItem/TagLabelList';
 import IcoMark from 'public/assets/svg/link.svg';
-import { Desc, InfoWrapper, LinkContents, Thumb } from '@/components/LinkItem/LinkItem.styled';
+import {
+  Desc,
+  InfoWrapper,
+  LinkContents,
+  Thumb,
+  UtilsWrapper,
+} from '@/components/LinkItem/LinkItem.styled';
 
 const LinkItemInfoWrapper = styled(InfoWrapper)`
   margin-bottom: 30px;
@@ -36,39 +42,6 @@ const LinkItemInfoWrapper = styled(InfoWrapper)`
 const Wrapper = styled.div`
   padding: 24px 0 16px;
   border-bottom: 1px solid #c8c8c8;
-
-  .utils {
-    display: flex;
-    justify-content: flex-end;
-
-    .read,
-    .mark {
-      display: flex;
-      flex-direction: row;
-
-      font-style: normal;
-      font-weight: 400;
-      font-size: 12px;
-      line-height: 14px;
-      color: #858585;
-    }
-
-    .read {
-      margin-right: 8px;
-    }
-
-    .mark {
-      cursor: pointer;
-    }
-
-    .icon {
-      position: relative;
-
-      width: 12px;
-      height: 12px;
-      margin-right: 4px;
-    }
-  }
 `;
 
 const Mark = styled.span<{ isActivated: boolean }>`
@@ -109,33 +82,34 @@ const LinkItem = ({ Header, queryKey, ...props }: LinkItemProps) => {
           <Thumbnail src={thumbnail} alt={title} />
         </LinkItemInfoWrapper>
 
-        <TagLabelList className='tag-list' tags={tagList} />
-
-        <div className='utils'>
-          {isRead && (
-            <div className='read'>
-              <div className='icon'>
-                <Image src='/assets/svg/check-green.svg' alt='' fill />
+        <UtilsWrapper>
+          <TagLabelList className='tag-list' tags={[{ tagId: 1, tagName: 'qwer' }]} />
+          <div className='utils'>
+            {isRead && (
+              <div className='read'>
+                <div className='icon'>
+                  <Image src='/assets/svg/check-green.svg' alt='' fill />
+                </div>
+                읽음
               </div>
-              읽음
-            </div>
-          )}
-          <button
-            className='mark'
-            type='button'
-            onClick={(e) => {
-              e.preventDefault();
-              handleToggleMark();
-            }}
-          >
-            <div className='icon'>
-              <Mark isActivated={isMark}>
-                <IcoMark />
-              </Mark>
-            </div>
-            {bookMarkCount}
-          </button>
-        </div>
+            )}
+            <button
+              className='mark'
+              type='button'
+              onClick={(e) => {
+                e.preventDefault();
+                handleToggleMark();
+              }}
+            >
+              <div className='icon'>
+                <Mark isActivated={isMark}>
+                  <IcoMark />
+                </Mark>
+              </div>
+              {bookMarkCount}
+            </button>
+          </div>
+        </UtilsWrapper>
       </article>
     </Wrapper>
   );

--- a/src/components/LinkItem/LinkItem.tsx
+++ b/src/components/LinkItem/LinkItem.tsx
@@ -12,6 +12,11 @@ import {
   UtilsWrapper,
 } from '@/components/LinkItem/LinkItem.styled';
 
+const Wrapper = styled.div`
+  padding: 24px 0 16px;
+  border-bottom: 1px solid #c8c8c8;
+`;
+
 const LinkItemInfoWrapper = styled(InfoWrapper)`
   margin-bottom: 30px;
 
@@ -37,11 +42,6 @@ const LinkItemInfoWrapper = styled(InfoWrapper)`
     white-space: nowrap;
     color: #c8c8c8;
   }
-`;
-
-const Wrapper = styled.div`
-  padding: 24px 0 16px;
-  border-bottom: 1px solid #c8c8c8;
 `;
 
 const Mark = styled.span<{ isActivated: boolean }>`


### PR DESCRIPTION
## 개요 :mag:

링크아이템 레이아웃 수정

## 작업사항 :memo:

북마크, 해시태그 영역을 정렬했습니다

[수정 전]
<img width="320" alt="스크린샷 2023-06-26 오전 4 36 39" src="https://github.com/linkarchive/Front-End/assets/123740296/6cf7ec1f-b830-43fb-8eaa-74061cc45e11">

[수정 후]
<img width="320" alt="스크린샷 2023-06-26 오전 4 36 29" src="https://github.com/linkarchive/Front-End/assets/123740296/475db775-eb81-4c4e-b7a8-ee3e7b485a9b">

- #134 


