### PR TITLE
Fix/optimize react query

### DIFF
--- a/src/hooks/useInfinityScroll.ts
+++ b/src/hooks/useInfinityScroll.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from 'react';
-import { QueryKey, useInfiniteQuery } from '@tanstack/react-query';
+import { QueryKey, UseInfiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 import useIntersectionObserver from '@/hooks/useIntersectionObserver';
 
@@ -9,9 +9,15 @@ interface IuseInfinityScroll {
   queryKey: QueryKey;
   fetchFn: (param?: unknown) => Promise<AxiosResponse<any, any>>;
   getNextPageParam?: (lastPage: any, pages: any) => any;
+  config?: UseInfiniteQueryOptions<unknown, unknown, unknown, unknown, QueryKey>;
 }
 
-const useInfinityScroll = <TPage>({ queryKey, fetchFn, getNextPageParam }: IuseInfinityScroll) => {
+const useInfinityScroll = <TPage>({
+  queryKey,
+  fetchFn,
+  getNextPageParam,
+  config,
+}: IuseInfinityScroll) => {
   const target = useRef(null);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
     queryKey,
@@ -19,7 +25,9 @@ const useInfinityScroll = <TPage>({ queryKey, fetchFn, getNextPageParam }: IuseI
       return fetchFn(pageParam || '');
     },
     getNextPageParam: (lastPage, pages) => getNextPageParam(lastPage, pages),
+    staleTime: 5000,
     retry: 1,
+    ...config,
   });
 
   const pages = (data?.pages as TPage[]) || [];

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -50,6 +50,7 @@ const Home = ({ accessToken }: { accessToken: string }) => {
 
       return lastItem;
     },
+    config: name !== '내 링크' && { staleTime: 0 },
   });
 
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,9 +17,11 @@ const Home = ({ accessToken }: { accessToken: string }) => {
   const dispatch = useAppDispatch();
 
   const { name } = useSelector((state: RootState) => state.home);
+  const myLink = name === '내 링크';
+  const myMark = !myLink;
 
   const fetchFn = (id: string) => {
-    return name === '내 링크' ? API.getUserLinksArchive(id) : API.getUserMarksArchive(id);
+    return myLink ? API.getUserLinksArchive(id) : API.getUserMarksArchive(id);
   };
 
   useEffect(() => {
@@ -38,7 +40,7 @@ const Home = ({ accessToken }: { accessToken: string }) => {
       const hasNext = lastPage_?.hasNext;
       if (!hasNext) return undefined;
 
-      if (name === '내 링크') {
+      if (myLink) {
         const lastPage = lastPage_?.linkList;
         const lastItem = lastPage[lastPage.length - 1].linkId;
 
@@ -50,7 +52,7 @@ const Home = ({ accessToken }: { accessToken: string }) => {
 
       return lastItem;
     },
-    config: name !== '내 링크' && { staleTime: 0 },
+    config: myMark && { staleTime: 0 },
   });
 
   return (


### PR DESCRIPTION
## 개요 :mag:

리액트 쿼리 config 옵션으로 최적화 했습니다.
내 링크, 내 마크,  둘러보기의 페이지 성격에 맞춰 config를 설정했습니다.
- 내 마크: 북마크 활성화/비활성화를 하므로 항상 최신 데이터 보장 
- 내 링크, 둘러보기: 페이지 이동이 잦으므로 일정 시간 후 최신 데이터 fetch

## 작업사항 :memo:

- 내 링크, 둘러보기:
   - `staleTime: 5000` 으로 데이터의 최신 상태를 5초간 보장해 `refetch`를 방지했습니다
- 내 마크:
   - `staleTime: 0` 으로 항상 최신 상태 데이터를 fetch 합니다
- #144 

close #144 

## 테스트 방법(optional)

`내 링크`의 스크롤 끝까지 내림 → `/archive` 이동 후 스크롤 끝까지 내림 → `내 링크` 이동 후 스크롤 끝까지 내림
같은 조건으로 데이터 패치 되는 양을 확인했습니다. 
적용 후 데이터 패치 건수가 줄었습니다

[적용 전]
<img width="792" alt="스크린샷 2023-06-26 오전 5 00 48" src="https://github.com/linkarchive/Front-End/assets/123740296/68e6c4ac-73ef-41b2-afee-4ade013f4596">

[적용 후]
<img width="864" alt="스크린샷 2023-06-26 오전 5 01 03" src="https://github.com/linkarchive/Front-End/assets/123740296/38160486-c61d-44b5-8ac1-2334eecac225">
