### PR TITLE
[fix] vercel basic 이슈로 image 최적화 끄기

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,5 +9,6 @@ module.exports = {
   },
   images: {
     domains: ['linkarchive-profile.s3.ap-northeast-2.amazonaws.com'],
+    unoptimized: true,
   },
 };


### PR DESCRIPTION
## 개요 :mag:

이미지 최적화를 함으로 vercel 블락당해서 이미지 최적화를 끄기로 결정
