### PR TITLE
[Feat] 해시태그 관리 페이지

### DIFF
--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -158,11 +158,12 @@ const API = {
     return data;
   },
 
+  /** 태그 등록 */
   createTag: async (tag: string) => {
-    const response = await clientInstance.post(`tag`, {
+    const { data } = await clientInstance.post(`tag`, {
       tag,
     });
-    return response;
+    return { data };
   },
 
   /**

--- a/src/components/Settings/FavoriteTagList/FavoriteTag.tsx
+++ b/src/components/Settings/FavoriteTagList/FavoriteTag.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import styled from 'styled-components';
+
+const Item = styled.li`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 10px;
+  height: 80px;
+
+  border-bottom: 1px solid #c8c8c8;
+
+  color: #0a1034;
+`;
+
+const StyledLink = styled(Link)`
+  color: #3a3a3a;
+  font-size: 12px;
+  font-weight: 400;
+`;
+
+export const FavoriteTag = ({ tag }: { tag: string }) => {
+  return (
+    <Item>
+      <div>{tag}</div>
+      <div>
+        <StyledLink href='#'>수정</StyledLink>
+      </div>
+    </Item>
+  );
+};

--- a/src/components/Settings/FavoriteTagList/index.tsx
+++ b/src/components/Settings/FavoriteTagList/index.tsx
@@ -36,10 +36,9 @@ export const FavoriteTagList = ({ usernickname }: { usernickname: string }) => {
     <InputBlock>
       <Title>자주 사용하는 태그</Title>
       <List>
-        <FavoriteTag tag='qwer' />
-        <FavoriteTag tag='qwer' />
-        <FavoriteTag tag='qwer' />
-        <FavoriteTag tag='qwer' />
+        {tagList.map(({ tagId, tagName }) => (
+          <FavoriteTag key={tagId} tag={tagName} />
+        ))}
       </List>
     </InputBlock>
   );

--- a/src/components/Settings/FavoriteTagList/index.tsx
+++ b/src/components/Settings/FavoriteTagList/index.tsx
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+import { FavoriteTag } from './FavoriteTag';
+import { useQuery } from '@tanstack/react-query';
+import API from '@/api/API';
+
+const Title = styled.p`
+  display: block;
+
+  margin-bottom: 8px;
+
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 21px;
+  color: var(--font-color-darkGray);
+`;
+
+const InputBlock = styled.div`
+  width: 327px;
+  padding: 0 5px;
+  margin: 0 auto;
+`;
+
+export const FavoriteTagList = ({ usernickname }: { usernickname: string }) => {
+  const { data: tagListData } = useQuery({
+    queryKey: ['user', 'tagList', 10],
+    queryFn: () => API.getTagsByNickname({ usernickname, size: 10 }),
+    retry: 1,
+  });
+  const tagList = tagListData?.tagList || [];
+
+  return (
+    <InputBlock>
+      <Title>자주 사용하는 태그</Title>
+      <ul>
+        <FavoriteTag tag='qwer' />
+        <FavoriteTag tag='qwer' />
+        <FavoriteTag tag='qwer' />
+        <FavoriteTag tag='qwer' />
+      </ul>
+    </InputBlock>
+  );
+};

--- a/src/components/Settings/FavoriteTagList/index.tsx
+++ b/src/components/Settings/FavoriteTagList/index.tsx
@@ -14,6 +14,10 @@ const Title = styled.p`
   color: var(--font-color-darkGray);
 `;
 
+const List = styled.ul`
+  width: 100%;
+`;
+
 const InputBlock = styled.div`
   width: 327px;
   padding: 0 5px;
@@ -31,12 +35,12 @@ export const FavoriteTagList = ({ usernickname }: { usernickname: string }) => {
   return (
     <InputBlock>
       <Title>자주 사용하는 태그</Title>
-      <ul>
+      <List>
         <FavoriteTag tag='qwer' />
         <FavoriteTag tag='qwer' />
         <FavoriteTag tag='qwer' />
         <FavoriteTag tag='qwer' />
-      </ul>
+      </List>
     </InputBlock>
   );
 };

--- a/src/components/Settings/FavoriteTagList/index.tsx
+++ b/src/components/Settings/FavoriteTagList/index.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { FavoriteTag } from './FavoriteTag';
 import { useQuery } from '@tanstack/react-query';
 import API from '@/api/API';
+import { useFetchTagsByNickname } from '@/queries';
 
 const Title = styled.p`
   display: block;
@@ -24,12 +25,8 @@ const InputBlock = styled.div`
   margin: 0 auto;
 `;
 
-export const FavoriteTagList = ({ usernickname }: { usernickname: string }) => {
-  const { data: tagListData } = useQuery({
-    queryKey: ['user', 'tagList', 10],
-    queryFn: () => API.getTagsByNickname({ usernickname, size: 10 }),
-    retry: 1,
-  });
+export const FavoriteTagList = ({ nickname }: { nickname: string }) => {
+  const { data: tagListData } = useFetchTagsByNickname({ nickname });
   const tagList = tagListData?.tagList || [];
 
   return (

--- a/src/components/Settings/TagForm/index.tsx
+++ b/src/components/Settings/TagForm/index.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { InputWithButton } from '@/components/Input';
+import { validateHashTag } from '@/utils/validation';
+
+const InputBlock = styled.div`
+  padding: 0 5px;
+  margin: 0 auto 54px;
+  width: 327px;
+`;
+
+// TODO post api 호출
+export const TagForm = () => {
+  const [tag, setTag] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const createHashTag = {
+    isLoading: false,
+  };
+
+  const handleSubmit = (e) => {
+    if (createHashTag.isLoading) return;
+
+    const errMsg = validateHashTag(tag);
+    const isFormValid = !errMsg;
+    if (!isFormValid) {
+      setErrorMessage(errMsg);
+      return;
+    }
+
+    console.log('api call'); // createHashTag.mutate({ tag });
+  };
+
+  return (
+    <InputBlock>
+      <InputWithButton
+        onClick={handleSubmit}
+        label='태그 추가'
+        text='추가'
+        placeholder='태그를 입력하세요.'
+        value={tag}
+        errMessage={errorMessage}
+        onChange={(e) => {
+          setTag(e.target.value);
+        }}
+      />
+    </InputBlock>
+  );
+};

--- a/src/components/Settings/TagForm/index.tsx
+++ b/src/components/Settings/TagForm/index.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import styled from 'styled-components';
 import { InputWithButton } from '@/components/Input';
 import { validateHashTag } from '@/utils/validation';
+import { useMutation } from '@tanstack/react-query';
+import API from '@/api/API';
 
 const InputBlock = styled.div`
   padding: 0 5px;
@@ -9,15 +11,27 @@ const InputBlock = styled.div`
   width: 327px;
 `;
 
-// TODO post api 호출
-export const TagForm = () => {
+export const TagForm = ({ onSuccess: onSubmit }: { onSuccess: () => void }) => {
   const [tag, setTag] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
-  const createHashTag = {
-    isLoading: false,
-  };
+  const createHashTag = useMutation({
+    mutationFn: API.createTag,
+    onSuccess: () => {
+      onSubmit();
+      setTag('');
+      setErrorMessage('');
+    },
+    onError: (error) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const d = error as any; // FIXME
+      if (d.response) {
+        const { message } = d.response.data;
+        setErrorMessage(message);
+      }
+    },
+  });
 
-  const handleSubmit = (e) => {
+  const handleSubmit = () => {
     if (createHashTag.isLoading) return;
 
     const errMsg = validateHashTag(tag);
@@ -27,7 +41,7 @@ export const TagForm = () => {
       return;
     }
 
-    console.log('api call'); // createHashTag.mutate({ tag });
+    createHashTag.mutate(tag);
   };
 
   return (

--- a/src/pages/create/index.tsx
+++ b/src/pages/create/index.tsx
@@ -16,6 +16,7 @@ import { createToastBar } from '@/store/slices/toastBarSlice';
 import HashTagList from '@/components/Create/HashTagList';
 import FavoriteTagList from '@/components/Create/FavoriteTagList';
 import { validateHashTag } from '@/utils/validation';
+import { useFetchTagsByNickname } from '@/queries';
 
 const defaultErrorMessages = {
   url: '',
@@ -27,7 +28,6 @@ export const getServerSideProps = withAuth();
 
 const Create = ({ nickname, accessToken }: { nickname: string; accessToken: string }) => {
   setAccessToken(accessToken);
-  const usernickname = nickname; // TODO getTagsByNickname 백엔드 작업 후 userId가 아닌 nickname으로 변경
 
   const dispatch = useAppDispatch();
 
@@ -65,11 +65,7 @@ const Create = ({ nickname, accessToken }: { nickname: string; accessToken: stri
     setErrorMessages(errmsgs);
   };
 
-  const { data: tagListData } = useQuery({
-    queryKey: ['user', 'tagList', 10],
-    queryFn: () => API.getTagsByNickname({ usernickname, size: 10 }),
-    retry: 1,
-  });
+  const { data: tagListData } = useFetchTagsByNickname({ nickname });
   const tagList = tagListData?.tagList || [];
 
   const { mutate: fetchMetaData, isLoading } = useMutation({

--- a/src/pages/create/index.tsx
+++ b/src/pages/create/index.tsx
@@ -15,6 +15,7 @@ import Spinner from '@/components/Spinner';
 import { createToastBar } from '@/store/slices/toastBarSlice';
 import HashTagList from '@/components/Create/HashTagList';
 import FavoriteTagList from '@/components/Create/FavoriteTagList';
+import { validateHashTag } from '@/utils/validation';
 
 const defaultErrorMessages = {
   url: '',
@@ -24,9 +25,9 @@ const defaultErrorMessages = {
 
 export const getServerSideProps = withAuth();
 
-const Create = ({ userId, accessToken }: { userId: string; accessToken: string }) => {
+const Create = ({ nickname, accessToken }: { nickname: string; accessToken: string }) => {
   setAccessToken(accessToken);
-  const usernickname = userId; // TODO getTagsByNickname 백엔드 작업 후 userId가 아닌 nickname으로 변경
+  const usernickname = nickname; // TODO getTagsByNickname 백엔드 작업 후 userId가 아닌 nickname으로 변경
 
   const dispatch = useAppDispatch();
 
@@ -277,10 +278,6 @@ const ERROR_MESSAGE = {
     INVALID: '제목을 입력해주세요',
   },
   HASHTAG: {
-    TOO_LONG: '최대 8글자 입력해주세요',
-    TOO_SHORT: '최소 2글자 입력해주세요',
-    NO_SPECIAL: '특수기호는 안돼요',
-    NO_SPACE: '공백을 제거해주세요',
     MAXIMUM: '최대 10개까지 등록할 수 있어요',
   },
 };
@@ -316,30 +313,6 @@ const validateHashTagList = (hashtagList: string[]): string => {
     .filter((errMesg) => errMesg !== '');
 
   return errors[0] || '';
-};
-
-const validateHashTag = (text: string): string => {
-  const whiteSpaceRegex = /\s/;
-  const specialSybmolsRegEx = /^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]+$/;
-  const isShort = text.length < 2; // 최소 2글자
-  const isLong = text.length > 8; // 최대 8글자
-  const hasWhitespace = whiteSpaceRegex.test(text); // 공백 불가
-  const hasSpecialSymbols = !specialSybmolsRegEx.test(text); // 특수기호, 이모지 불가
-
-  if (isShort) {
-    return ERROR_MESSAGE.HASHTAG.TOO_SHORT;
-  }
-  if (isLong) {
-    return ERROR_MESSAGE.HASHTAG.TOO_LONG;
-  }
-  if (hasWhitespace) {
-    return ERROR_MESSAGE.HASHTAG.NO_SPACE;
-  }
-  if (hasSpecialSymbols) {
-    return ERROR_MESSAGE.HASHTAG.NO_SPECIAL;
-  }
-
-  return '';
 };
 
 const validateUrl = (url: string): string => {

--- a/src/pages/settings/hashtag/index.tsx
+++ b/src/pages/settings/hashtag/index.tsx
@@ -1,25 +1,36 @@
 import { TagForm } from '@/components/Settings/TagForm';
 import { FavoriteTagList } from '@/components/Settings/FavoriteTagList';
 import { useAppDispatch } from '@/store';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { routerSlice } from '@/store/slices/routerSlice';
 import styled from 'styled-components';
+import { withAuth } from '@/lib/withAuth';
+import { useQueryClient } from '@tanstack/react-query';
 
 const Wrapper = styled.div`
   margin-top: 23px;
 `;
 
-const Page = () => {
+export const getServerSideProps = withAuth();
+
+const Page = ({ nickname }: { nickname: string }) => {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
     dispatch(routerSlice.actions.loadConfigHashtag());
   }, [dispatch]);
 
+  const queryClient = useQueryClient();
+  const updateFavoriteTagList = () => {
+    queryClient.fetchQuery({
+      queryKey: ['user', 'tagList', 10], // TODO 페이지네이션
+    });
+  };
+
   return (
     <Wrapper>
-      <TagForm />
-      <FavoriteTagList usernickname='' />
+      <TagForm onSuccess={updateFavoriteTagList} />
+      <FavoriteTagList usernickname={nickname} />
     </Wrapper>
   );
 };

--- a/src/pages/settings/hashtag/index.tsx
+++ b/src/pages/settings/hashtag/index.tsx
@@ -6,6 +6,7 @@ import { routerSlice } from '@/store/slices/routerSlice';
 import styled from 'styled-components';
 import { withAuth } from '@/lib/withAuth';
 import { useQueryClient } from '@tanstack/react-query';
+import { setAccessToken } from '@/api/customAPI';
 
 const Wrapper = styled.div`
   margin-top: 23px;
@@ -13,7 +14,9 @@ const Wrapper = styled.div`
 
 export const getServerSideProps = withAuth();
 
-const Page = ({ nickname }: { nickname: string }) => {
+const Page = ({ accessToken, nickname }: { accessToken: string; nickname: string }) => {
+  setAccessToken(accessToken);
+
   const dispatch = useAppDispatch();
 
   useEffect(() => {

--- a/src/pages/settings/hashtag/index.tsx
+++ b/src/pages/settings/hashtag/index.tsx
@@ -33,7 +33,7 @@ const Page = ({ accessToken, nickname }: { accessToken: string; nickname: string
   return (
     <Wrapper>
       <TagForm onSuccess={updateFavoriteTagList} />
-      <FavoriteTagList usernickname={nickname} />
+      <FavoriteTagList nickname={nickname} />
     </Wrapper>
   );
 };

--- a/src/pages/settings/hashtag/index.tsx
+++ b/src/pages/settings/hashtag/index.tsx
@@ -1,0 +1,27 @@
+import { TagForm } from '@/components/Settings/TagForm';
+import { FavoriteTagList } from '@/components/Settings/FavoriteTagList';
+import { useAppDispatch } from '@/store';
+import { useEffect } from 'react';
+import { routerSlice } from '@/store/slices/routerSlice';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  margin-top: 23px;
+`;
+
+const Page = () => {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(routerSlice.actions.loadConfigHashtag());
+  }, [dispatch]);
+
+  return (
+    <Wrapper>
+      <TagForm />
+      <FavoriteTagList usernickname='' />
+    </Wrapper>
+  );
+};
+
+export default Page;

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -26,7 +26,7 @@ const Settings = () => {
       <Link href='/settings/profile'>
         <h3>프로필</h3>
       </Link>
-      <Link href=''>
+      <Link href='/settings/hashtag'>
         <h3>해시태그 관리</h3>
       </Link>
       <Link href=''>

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,0 +1,15 @@
+import API from '@/api/API';
+import { useQuery } from '@tanstack/react-query';
+
+export const useFetchTagsByNickname = ({
+  nickname: usernickname,
+  size = 10,
+}: {
+  nickname: string;
+  size?: number;
+}) =>
+  useQuery({
+    queryKey: [usernickname, 'tagList', size],
+    queryFn: () => API.getTagsByNickname({ usernickname, size: 10 }),
+    retry: 1,
+  });

--- a/src/store/slices/routerSlice.ts
+++ b/src/store/slices/routerSlice.ts
@@ -45,6 +45,11 @@ export const routerSlice = createSlice({
       state.current = 'PROFILE';
       state.name = '프로필';
     },
+    loadConfigHashtag(state) {
+      state.status = 'OTHER';
+      state.current = 'Hashtag';
+      state.name = '해시태그 관리';
+    },
     // 페이지 추가시 reducer추가
   },
 });

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,34 @@
+const ERROR_MESSAGE = {
+  HASHTAG: {
+    TOO_LONG: '최대 8글자 입력해주세요',
+    TOO_SHORT: '최소 2글자 입력해주세요',
+    NO_SPECIAL: '특수기호는 안돼요',
+    NO_SPACE: '공백을 제거해주세요',
+  },
+};
+
+const validateHashTag = (text: string): string => {
+  const whiteSpaceRegex = /\s/;
+  const specialSybmolsRegEx = /^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]+$/;
+  const isShort = text.length < 2; // 최소 2글자
+  const isLong = text.length > 8; // 최대 8글자
+  const hasWhitespace = whiteSpaceRegex.test(text); // 공백 불가
+  const hasSpecialSymbols = !specialSybmolsRegEx.test(text); // 특수기호, 이모지 불가
+
+  if (isShort) {
+    return ERROR_MESSAGE.HASHTAG.TOO_SHORT;
+  }
+  if (isLong) {
+    return ERROR_MESSAGE.HASHTAG.TOO_LONG;
+  }
+  if (hasWhitespace) {
+    return ERROR_MESSAGE.HASHTAG.NO_SPACE;
+  }
+  if (hasSpecialSymbols) {
+    return ERROR_MESSAGE.HASHTAG.NO_SPECIAL;
+  }
+
+  return '';
+};
+
+export { validateHashTag };


### PR DESCRIPTION
## 개요 :mag:

- https://github.com/linkarchive/Front-End/issues/181

## 작업사항 :memo:

 - 해시태그 추가 API 연동
-  자주 사용하는 태그 API 연동

`/queries` 디렉토리를 추가해 query 훅을 분리하였습니다

## 기타
자주 사용하는 태그 무한스크롤이 추가로 구현이 필요합니다(이슈에 TODO 추가하겠습니다!)
