### PR TITLE
[Refactor] ProfileImage 디렉토리 변경

### DIFF
--- a/src/components/Archive/User/ProfileImage.tsx
+++ b/src/components/Archive/User/ProfileImage.tsx
@@ -1,26 +1,3 @@
-import Image from 'next/image';
-import styled from 'styled-components';
-
-interface ProfileImageProps {
-  src: string;
-  size: string;
-}
-
-const ProfileImage = ({ src, size }: ProfileImageProps) => {
-  return (
-    <Wrapper size={size}>
-      <Image alt='profile_image' src={src} fill />
-    </Wrapper>
-  );
-};
-
-const Wrapper = styled.div<Omit<ProfileImageProps, 'src'>>`
-  position: relative;
-  overflow: hidden;
-
-  width: ${({ size }) => size};
-  height: ${({ size }) => size};
-  border-radius: 100%;
-`;
+import ProfileImage from '@/components/Common/User/ProfileImage';
 
 export default ProfileImage;

--- a/src/components/Common/User/ProfileImage.tsx
+++ b/src/components/Common/User/ProfileImage.tsx
@@ -1,0 +1,26 @@
+import Image from 'next/image';
+import styled from 'styled-components';
+
+interface ProfileImageProps {
+  src: string;
+  size: string;
+}
+
+const ProfileImage = ({ src, size }: ProfileImageProps) => {
+  return (
+    <Wrapper size={size}>
+      <Image alt='profile_image' src={src} fill />
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div<Omit<ProfileImageProps, 'src'>>`
+  position: relative;
+  overflow: hidden;
+
+  width: ${({ size }) => size};
+  height: ${({ size }) => size};
+  border-radius: 100%;
+`;
+
+export default ProfileImage;


### PR DESCRIPTION
## 개요 :mag:

링크 아이템 컴포넌트 리팩토링 중 `ProfileImage` 컴포넌트를 사용해야해서
`Archive` 도메인에 있는 `ProfileImage` 를 공통 디렉토리 `Common`으로 이동했습니다.

## 작업사항 :memo:

- #231

## 특이사항
기존 `Archive/User/ProfileImage`는 삭제하지 않고 `Common/User/ProfileImage`를 참조하는데 이에 관해서 코멘트 달아주세여


