### PR TITLE
[HOTFIX] api response 변수 변경

### DIFF
--- a/__test__/Profile/mocks/handlers.js
+++ b/__test__/Profile/mocks/handlers.js
@@ -10,14 +10,14 @@ export const handlers = [
         id: 1,
         nickname: 'nickname test',
         introduce: 'introduce test',
-        profileImageFileName: 'test',
+        profileImage: 'test',
       })
     );
   }),
 
   /** 이미지 변경 */
   rest.patch(`${API_BASE_URL}/profile-image`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ profileImageFileName: '/new-image.png' }));
+    return res(ctx.status(200), ctx.json({ profileImage: '/new-image.png' }));
   }),
 
   /** 로그아웃 */

--- a/__test__/Settings/mocks/handlers.js
+++ b/__test__/Settings/mocks/handlers.js
@@ -10,14 +10,14 @@ export const handlers = [
         id: 1,
         nickname: 'nickname test',
         introduce: 'introduce test',
-        profileImageFileName: 'test',
+        profileImage: 'test',
       })
     );
   }),
 
   /** 이미지 변경 */
   rest.patch(`${API_BASE_URL}/profile-image`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ profileImageFileName: '/new-image.png' }));
+    return res(ctx.status(200), ctx.json({ profileImage: '/new-image.png' }));
   }),
 
   /** 로그아웃 */

--- a/src/components/Archive/Follower/Follower.type.ts
+++ b/src/components/Archive/Follower/Follower.type.ts
@@ -2,7 +2,7 @@ interface IFollower {
   userId: number;
   nickname: string;
   introduce: string;
-  profileImageFileName: string;
+  profileImage: string;
   isFollow: boolean;
 }
 

--- a/src/components/Archive/Follower/FollowerList.tsx
+++ b/src/components/Archive/Follower/FollowerList.tsx
@@ -100,7 +100,7 @@ const Follower = ({
   nickname,
   userId,
   introduce,
-  profileImageFileName,
+  profileImage,
   isFollow,
   isUser,
 }: IFollower & { isUser: boolean }) => {
@@ -155,7 +155,7 @@ const Follower = ({
         <Link href={`/${userId}`}>
           <Box>
             <ProfileImage>
-              <Image alt='' src={profileImageFileName} fill />
+              <Image alt='' src={profileImage} fill />
             </ProfileImage>
             <TextInfoBox>
               <Nickname>{nickname}</Nickname>

--- a/src/components/Archive/User/Profile.tsx
+++ b/src/components/Archive/User/Profile.tsx
@@ -22,7 +22,7 @@ const Profile = ({
   id,
   nickname,
   introduce,
-  profileImageFileName,
+  profileImage,
   followerCount,
   followingCount,
   isFollow,
@@ -83,7 +83,7 @@ const Profile = ({
           <ProfileIntro>{introduce}</ProfileIntro>
         </div>
 
-        <ProfileImage src={profileImageFileName} size='72px' />
+        <ProfileImage src={profileImage} size='72px' />
       </ProfileWrapper>
 
       <InteractiveWrapper>

--- a/src/components/Archive/User/User.type.ts
+++ b/src/components/Archive/User/User.type.ts
@@ -1,6 +1,6 @@
 type User = {
   id: number;
-  profileImageFileName: string;
+  profileImage: string;
   nickname: string;
   introduce: string;
 };

--- a/src/components/LinkItem/LinkItem.tsx
+++ b/src/components/LinkItem/LinkItem.tsx
@@ -61,7 +61,7 @@ const Thumbnail = ({ src, alt }: { src: string; alt: string }) => {
 };
 
 const LinkItem = ({ Header, queryKey, ...props }: LinkItemProps) => {
-  const { linkId, url, title, description, thumbnail, isRead, isMark, bookMarkCount, tagList } =
+  const { linkId, url, title, description, thumbnail, isRead, isMark, bookmarkCount, tagList } =
     props;
   const { handleToggleMark } = useToggleMark({ linkId, isMark, queryKey });
 
@@ -113,7 +113,7 @@ const LinkItem = ({ Header, queryKey, ...props }: LinkItemProps) => {
                   <IcoMark />
                 </Mark>
               </div>
-              {bookMarkCount}
+              {bookmarkCount}
             </button>
           </div>
         </UtilsWrapper>

--- a/src/components/LinkItem/LinkItem.type.ts
+++ b/src/components/LinkItem/LinkItem.type.ts
@@ -7,7 +7,7 @@ interface ILinkItem {
   markId?: number;
   linkId: number;
   url: string;
-  bookMarkCount: number;
+  bookmarkCount: number;
   isRead: boolean;
   isMark: boolean;
   tagList: Tag[];

--- a/src/components/Settings/ProfileCard.tsx
+++ b/src/components/Settings/ProfileCard.tsx
@@ -4,19 +4,19 @@ import ProfileImage from '../Archive/User/ProfileImage';
 import Link from 'next/link';
 
 interface ProfileCardProps {
-  profileImageFileName: string;
+  profileImage: string;
   nickname: string;
   followerCount: number;
   followingCount: number;
 }
 
 const ProfileCard = ({ ...data }: ProfileCardProps) => {
-  const { profileImageFileName, nickname, followerCount, followingCount } = data;
+  const { profileImage, nickname, followerCount, followingCount } = data;
 
   return (
     <Info>
       <ProfileWrapper>
-        <ProfileImage src={profileImageFileName} size='72px' />
+        <ProfileImage src={profileImage} size='72px' />
         <Username>{nickname}</Username>
       </ProfileWrapper>
       <InteractiveWrapper>

--- a/src/hooks/useImage.ts
+++ b/src/hooks/useImage.ts
@@ -15,7 +15,7 @@ export const useImage = (initialImageUrl: string) => {
       { file },
       {
         onSuccess: (response) => {
-          setImageUrl(response.data.profileImageFileName);
+          setImageUrl(response.data.profileImage);
         },
         onError: () => {
           // eslint-disable-next-line no-console

--- a/src/hooks/useToggleMark.ts
+++ b/src/hooks/useToggleMark.ts
@@ -42,7 +42,7 @@ export const useToggleMark = ({
 };
 
 /**
- * linkItem의 isMark와 bookMarkCount 상태 업데이트
+ * linkItem의 isMark와 bookmarkCount 상태 업데이트
  */
 function updateLinkItem({ linkList, linkId }: { linkList: unknown; key?: string; linkId: number }) {
   const keys = ['linkArchive', 'linkList', 'markList']; // TODO key를 인자로 받도록 하드코딩 개선
@@ -54,7 +54,7 @@ function updateLinkItem({ linkList, linkId }: { linkList: unknown; key?: string;
         page[key] = page[key].map((link) => {
           if (link.linkId === linkId) {
             link.isMark = !link.isMark;
-            link.bookMarkCount += link.isMark ? 1 : -1;
+            link.bookmarkCount += link.isMark ? 1 : -1;
           }
           return link;
         });

--- a/src/layouts/LinkItemLayout.tsx
+++ b/src/layouts/LinkItemLayout.tsx
@@ -92,7 +92,7 @@ const Wrapper = styled.div`
 
 const TagGroup = styled.div<{ isButtonClicked: boolean }>`
   position: relative;
-  height: ${({ isButtonClicked }) => (isButtonClicked ? '150px' : '55px')};
+  max-height: ${({ isButtonClicked }) => (isButtonClicked ? '135px' : '55px')};
   padding: 4px;
   border-bottom: 8px solid ${({ theme }) => theme.gray.lightBlack};
   overflow-x: hidden;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,13 +12,13 @@ export function middleware(request: NextRequest) {
 
   if (isLoggedIn) {
     // 닉네임 설정 페이지 허용
-    if (!nickname && request.nextUrl.pathname === `/settings/profile/set-nickname`) {
+    if (!nickname && request.nextUrl.pathname === `/settings/profile/nickname`) {
       return NextResponse.next();
     }
 
     // 닉네임 설정 페이지로 이동
     if (!nickname) {
-      return NextResponse.redirect(`${request.nextUrl.origin}/settings/profile/set-nickname`);
+      return NextResponse.redirect(`${request.nextUrl.origin}/settings/profile/nickname`);
     }
 
     // 로그인 페이지 접근 불가

--- a/src/pages/settings/profile/index.tsx
+++ b/src/pages/settings/profile/index.tsx
@@ -108,7 +108,7 @@ const Profile = ({ accessToken }: { accessToken: string }) => {
       introduce: { value: data?.introduce, initialValue: data?.introduce },
     });
 
-    setImageUrl(data?.profileImageFileName);
+    setImageUrl(data?.profileImage);
   };
 
   const validateNicknameMutation = useMutation(API.validateNickname, {


### PR DESCRIPTION
## 개요 :mag:

백엔드에서 response 변수 이름 변경으로 프론트엔드 변수도 수정했어요

## 변경 사항

`
- 로그인 유저의 프로필 조회
 /user
 MyProfileResponse
profileImageFileName -> profileImage

- 사용자 별 프로필 조회
/user/{userId}
UserProfileResponse
profileImageFileName -> profileImage

- 팔로워/팔로잉 리스트 조회
follower-list/user/{userId}
following-list/user/{userId}
FollowListResponse
followResponseList (followList)
profileImageFileName -> profileImage

- 프로필 이미지 수정
/profile-image
ProfileImageResponse
profileImageFileName -> profileImage

- 내 링크 리스트 조회 / 사용자 별 링크 리스트 조회
/links/user , /links/user{userId}
UserLinkListResponse
UserLinkResponse (linkList)
bookMarkCount -> bookmarkCount

- 링크 둘러보기
/links/archive
UserLinkArchiveResponse
UserArchiveResponse (linkArchive)
bookMarkCount -> bookmarkCount

- 링크 삭제 보관함 조회
/links/trash
UserTrashLinkListResponse
TrashLinkListResponse (LinkList)
bookMarkCount -> bookmarkCount

- 내 북마크 리스트 조회 / 사용자별 북마크 리스트 조회
/mark/links/user
/mark/links/user/{userId}
UserMarkListResponse
UserMarkResponse (markList)
bookMarkCount -> bookmarkCount
bookMarkedTime -> bookmarkedTime`