### PR TITLE
[Fix] 해시태그 최대 등록 개수 버그 해결

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,4 +1,8 @@
 const ERROR_MESSAGE = {
+  TITLE: {
+    INVALID: '제목을 입력해주세요',
+    MAXIMUM: '255자만 입력이 가능합니다.',
+  },
   HASHTAG: {
     TOO_LONG: '최대 8글자 입력해주세요',
     TOO_SHORT: '최소 2글자 입력해주세요',
@@ -31,4 +35,27 @@ const validateHashTag = (text: string): string => {
   return '';
 };
 
-export { validateHashTag };
+const validateUrl = (url: string): string => {
+  const urlRegex =
+    // eslint-disable-next-line no-useless-escape
+    /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/;
+  if (!urlRegex.test(url)) return ERROR_MESSAGE.URL.INVALID;
+
+  return '';
+};
+
+const validateHashTagList = (hashtagList: string[]): string => {
+  const MAX_HASHTAG = 10; // 최대 10개 등록 가능
+
+  if (hashtagList.length > MAX_HASHTAG) {
+    return ERROR_MESSAGE.HASHTAG.MAXIMUM;
+  }
+
+  const errors = hashtagList
+    .map((hashtag) => validateHashTag(hashtag))
+    .filter((errMesg) => errMesg !== '');
+
+  return errors[0] || '';
+};
+
+export { validateHashTag, validateUrl, ERROR_MESSAGE, validateHashTagList };


### PR DESCRIPTION
## 개요 :mag:

해시태그가 9개만 등록되는 버그 해결

## 작업사항 :memo:

최대 등록 개수인 10개로 수정

## 테스트 방법(optional)

